### PR TITLE
FAIMMS config

### DIFF
--- a/FAIMMS/FAIMMS_data_rss_channels_process_matlab/README
+++ b/FAIMMS/FAIMMS_data_rss_channels_process_matlab/README
@@ -1,7 +1,5 @@
-FAIMMS_realtime V2.5# Readme
-Oct 2012
+FAIMMS_realtime
 
-Thank you for using FAIMMS_realtime, version 2.5. The readme contains the following main sections:
 
 Installation
 System requirements
@@ -45,17 +43,6 @@ https://svn.emii.org.au/repos/FAIMMS_CURRENT_JOB/trunk/
 
 == Upgrade Issue Heading ==
 
-
-== New Features Added ==
-The following features were added in V2.0:
--better reporting
--better integration of both QAQC and RAW data
-
-
-== Fixed Issues ==
-The following issues were fixed in V2.0
-
-Issue ID	Summary
 
 
 == Tips ==

--- a/FAIMMS/FAIMMS_data_rss_channels_process_matlab/config.txt
+++ b/FAIMMS/FAIMMS_data_rss_channels_process_matlab/config.txt
@@ -10,17 +10,18 @@
 script.path		= /mnt/ebs/data-services/FAIMMS/FAIMMS_data_rss_channels_process_matlab
 
 ## [PYTHON PATH location]
-python.path			= /usr/bin/python
+python.path		= /usr/bin/python
 
 ## [MATLAB bin location]
-matlab.path			=/usr/local/bin/matlab
+matlab.path		= /usr/local/bin/matlab
 
-## [data folder location] where files will be proccessed
-dataFAIMMS.path			= /mnt/imos-t4/project_officers/wip/FAIMMS/faimms_data_rss_download_temporary
+## [data folder location] where files will be proccessed temporary
+dataFAIMMS.path		= /mnt/imos-t4/project_officers/wip/FAIMMS/faimms_data_rss_download_temporary
 
-## [datafabric folder location]
-df.path				= /mnt/imos-t4/project_officers/wip/FAIMMS/data_opendap_folder_rsync
-destination.path	= /mnt/imos-t3/IMOS/opendap/FAIMMS
+## [opendap folder location]
+df.path			= /mnt/imos-t4/project_officers/wip/FAIMMS/data_opendap_folder_rsync
+destination.path	= /mnt/opendap/1/IMOS/opendap/FAIMMS
+
 
 ## [database options]
 database.name		= maplayers
@@ -30,16 +31,16 @@ database.port		= 5432
 database.host		= db.emii.org.au
 
 ## [logfile name]  (stored in dataFAIMMS.path)
-logFile.name 			= FAIMMS_Log.txt
+logFile.name 		= FAIMMS_Log.txt
 
 ## [email] only if there is a mail server installed on the machine
-email1.log			= laurent.besnard@utas.edu.au
-#email2.log			= sebastien.mancini@utas.edu.au
+email1.log		= laurent.besnard@utas.edu.au
+#email2.log		= sebastien.mancini@utas.edu.au
 
 ######################################################################################
 ## FAIMMS XML
-xmlRSS.address.level1			= http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level1/1
-xmlRSS.address.level0			= http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level0/1
+xmlRSS.address.level1	= http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level1/1
+xmlRSS.address.level0	= http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level0/1
 
 
 ## crontab entry


### PR DESCRIPTION
The data path to opendap was wrong. it was the old address /mnt/imos-t4/IMOS/opendap ...
Actually a symbolic link could be a good way to keep the same logical structure
