### PR TITLE
SOOP TRV CRON

### DIFF
--- a/cron.d/SOOP_TRV_RSS
+++ b/cron.d/SOOP_TRV_RSS
@@ -1,0 +1,2 @@
+MAILTO=laurent.besnard@utas.edu.au
+0 20 * * * lbesnard SOOP/SOOP_TRV_aims_download_process_matlab/SOOP_TRV.sh


### PR DESCRIPTION
 Migration of SOOP TRV from NSP5 to NSP10
- cron file removed on NSP5
- new file for NSP10. run everyday
