### PR TITLE
AATAMS - NRT - CRON

### DIFF
--- a/AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh
+++ b/AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh
@@ -68,7 +68,7 @@ lockfile=${DIR}/${APP_NAME}.lock
 
     # rsync data between rsyncSourcePath and rsyncDestinationPath
     rsyncSourcePath=$dataWIPPath
-    rsync --dry-run --size-only --itemize-changes --delete-before  --stats -uhvrD  --progress ${rsyncSourcePath}/NETCDF/  ${dataDestinationPath}/ ;
+    rsync --size-only --itemize-changes --delete-before  --stats -uhvrD  --progress ${rsyncSourcePath}/NETCDF/  ${dataDestinationPath}/ ;
 
 
 } 9>"$lockfile"

--- a/cron.d/AATAMS_SATTAG_NRT
+++ b/cron.d/AATAMS_SATTAG_NRT
@@ -1,0 +1,10 @@
+MAILTO=laurent.besnard@utas.edu.au
+# m h  dom mon dow   command
+# .---------------- minute (0 - 59)
+# |  .------------- hour (0 - 23)
+# |  |  .---------- day of month (1 - 31)
+# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
+# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
+# |  |  |  |  |
+# *  *  *  *  * user-name  command to be executed
+0 0,12  * * * lbesnard AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh


### PR DESCRIPTION
- removed the --dry-run option from the rsync command. Manual testing
  performed without any problems
- Add crontab entry to run the NRT job twice a day
