### PR TITLE
AATAMS NRT CRON fix

### DIFF
--- a/cron.d/AATAMS_SATTAG_NRT
+++ b/cron.d/AATAMS_SATTAG_NRT
@@ -6,5 +6,13 @@ MAILTO=laurent.besnard@utas.edu.au
 # |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
 # |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
 # |  |  |  |  |
-# *  *  *  *  * user-name  command to be executed
+# *  *  *  *  * user-name  command to be executedI
+
+# set up env variables see http://au.mathworks.com/matlabcentral/answers/29716-running-matlab-script-through-unix-bash-script
+export USER=lbesnard
+export LOGNAME=lbesnard
+export HOME=/home/lbesnard
+export LANG=en_AU.UTF-8
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+
 0 0,12  * * * lbesnard AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh


### PR DESCRIPTION
- running the shell script manually performs right, but launching from crontab,
  the matlab command seems not to be found.
- this error can apparently be fixed by exporting env variables in the cron file,
  see :
  http://au.mathworks.com/matlabcentral/answers/29716-running-matlab-script-through-unix-bash-script
