### PR TITLE
fix aatams cronjobs

### DIFF
--- a/AATAMS/AATAMS_sattag_dm/aatams_sattag_dm_main.sh
+++ b/AATAMS/AATAMS_sattag_dm/aatams_sattag_dm_main.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-export LOGNAME
-export HOME
-export PATH
+
+# set up env variables see http://au.mathworks.com/matlabcentral/answers/29716-running-matlab-script-through-unix-bash-script
+export LOGNAME=lbesnard
+export HOME=/tmp
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
 
 APP_NAME='AATAMS_SATTAG_DM'
 DIR=/tmp

--- a/AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh
+++ b/AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-export LOGNAME
-export HOME
-export PATH
+
+# set up env variables see http://au.mathworks.com/matlabcentral/answers/29716-running-matlab-script-through-unix-bash-script
+export LOGNAME=lbesnard
+export HOME=/tmp
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
 
 APP_NAME='AATAMS_SATTAG_NRT'
 DIR=/tmp

--- a/cron.d/AATAMS_SATTAG_DM
+++ b/cron.d/AATAMS_SATTAG_DM
@@ -1,16 +1,5 @@
-MAILTO=laurent.besnard@utas.edu.au
-# m h  dom mon dow   command
-# .---------------- minute (0 - 59)
-# |  .------------- hour (0 - 23)
-# |  |  .---------- day of month (1 - 31)
-# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
-# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
-# |  |  |  |  |
-# *  *  *  *  * user-name  command to be executedI
+SHELL=/bin/bash
 
-# set up env variables see http://au.mathworks.com/matlabcentral/answers/29716-running-matlab-script-through-unix-bash-script
-LOGNAME=lbesnard
-HOME=/tmp
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+MAILTO=laurent.besnard@utas.edu.au
 
 0 0,12 * * * lbesnard AATAMS/AATAMS_sattag_dm/aatams_sattag_dm_main.sh

--- a/cron.d/AATAMS_SATTAG_NRT
+++ b/cron.d/AATAMS_SATTAG_NRT
@@ -1,16 +1,5 @@
-MAILTO=laurent.besnard@utas.edu.au
-# m h  dom mon dow   command
-# .---------------- minute (0 - 59)
-# |  .------------- hour (0 - 23)
-# |  |  .---------- day of month (1 - 31)
-# |  |  |  .------- month (1 - 12) OR jan,feb,mar,apr ...
-# |  |  |  |  .---- day of week (0 - 6) (Sunday=0 or 7) OR sun,mon,tue,wed,thu,fri,sat
-# |  |  |  |  |
-# *  *  *  *  * user-name  command to be executedI
+SHELL=/bin/bash
 
-# set up env variables see http://au.mathworks.com/matlabcentral/answers/29716-running-matlab-script-through-unix-bash-script
-LOGNAME=lbesnard
-HOME=/tmp
-PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games
+MAILTO=laurent.besnard@utas.edu.au
 
 0 0,12 * * * lbesnard AATAMS/AATAMS_sattag_nrt/aatams_sattag_nrt_main.sh


### PR DESCRIPTION
not allowing to set variables in cronjob

@lbesnard sorry, I forgot variables are not allowed in the cronjob entries (except for `SHELL` and `MAILTO`).
