### PR TITLE
perserve hierarchy in graveyard

### DIFF
--- a/lib/common/util.sh
+++ b/lib/common/util.sh
@@ -10,6 +10,18 @@ _unique_timestamp() {
 }
 export -f _unique_timestamp
 
+# generate graveyard file name. flattens name by changing all / to _ and adds
+# timestamp. example:
+# /mnt/opendap/1/file.nc -> _mnt_opendap_1_file.nc.TIMESTAMP
+# $1 - full path to file
+_graveyard_file_name() {
+    local file=$1; shift
+    local graveyard_file_name=`echo $file | sed -e 's#/#_#g'`
+    graveyard_file_name="$graveyard_file_name".`_unique_timestamp`
+    echo $graveyard_file_name
+}
+export -f _graveyard_file_name
+
 # set standard permissions on target file
 # $1 - file
 _set_permissions() {
@@ -65,7 +77,7 @@ _remove_file() {
         # create graveyard if it doesn't exist
         test -d $GRAVEYARD_DIR || mkdir -p $GRAVEYARD_DIR || return 1
 
-        local dst=$GRAVEYARD_DIR/`basename $file`.`_unique_timestamp`
+        local dst=$GRAVEYARD_DIR/`_graveyard_file_name $file`
         log_info "Removing '$file', buried in graveyard as '$dst'"
         if ! mv $file $dst; then
             log_error "Error renaming '$file' to '$dst'"

--- a/lib/test/common/shunit2_test.sh
+++ b/lib/test/common/shunit2_test.sh
@@ -1,9 +1,24 @@
 #!/bin/bash
 
+# test _graveyard_file_name
+test_graveyard_file_name() {
+    local tmp_file=`mktemp`
+    function _unique_timestamp() { echo "TIMESTAMP"; }
+
+    # absolute path
+    assertEquals "_mnt_opendap_1_file.nc.TIMESTAMP" `_graveyard_file_name /mnt/opendap/1/file.nc`
+    assertEquals "_mnt_opendap_1_file.nc_.TIMESTAMP" `_graveyard_file_name /mnt/opendap/1/file.nc/`
+
+    # relative path
+    assertEquals "opendap_1_ACORN_file.nc.TIMESTAMP" `_graveyard_file_name opendap/1/ACORN/file.nc`
+
+    # make sure there are no new slashes in the name
+    assertFalse "_graveyard_file_name /mnt/opendap/1/file.nc | grep '/'"
+}
+
 # test _set_permissions function
 test_set_permissions() {
     local tmp_file=`mktemp`
-    alias sudo="" # mock sudo
     _set_permissions $tmp_file
 
     local file_perms=`stat --format=%a $tmp_file`
@@ -37,7 +52,7 @@ test_move_to_fs_file_exists_with_force() {
     local dest_dir=`mktemp -d`
     local dest_file="$dest_dir/some_file"
 
-    function _unique_timestamp() { echo "timestamp"; }
+    function _graveyard_file_name() { echo "graveyard_file_name"; }
 
     export GRAVEYARD_DIR=`mktemp -d`
 
@@ -45,7 +60,7 @@ test_move_to_fs_file_exists_with_force() {
 
     _move_to_fs_force $src_file $dest_file
 
-    assertTrue "some_file moved to graveyard" "test -f $GRAVEYARD_DIR/some_file.timestamp"
+    assertTrue "some_file moved to graveyard" "test -f $GRAVEYARD_DIR/graveyard_file_name"
     assertTrue "new file is now in production" "test -f $dest_dir/some_file"
 
     local new_file_content=`cat $dest_dir/some_file`


### PR DESCRIPTION
graveyard hierarchy will still be flat, but flatten file names so at
least one can know where they came from. flattening is done by
replacing all slashes (/) to underscores (_), giving the file a new
name which can be traced back to where it came from

i thought about it only after seeing what happens in production, this will results in graveyard files like:

```
_mnt_opendap_1_IMOS_opendap_ACORN_radial_NNB_2015_01_28_IMOS_ACORN_RV_20150128T065500Z_NNB_FV00_radial.nc.20150702-170913
```

ideally, once we're on S3, there will be no graveyard, but simple file versioning.
