### PR TITLE
set permissions before graveyard moving

### DIFF
--- a/lib/common/util.sh
+++ b/lib/common/util.sh
@@ -77,6 +77,10 @@ _remove_file() {
         # create graveyard if it doesn't exist
         test -d $GRAVEYARD_DIR || mkdir -p $GRAVEYARD_DIR || return 1
 
+        # handle files in production with 000 permissions before they are
+        # moved to graveyard (nfs errors)
+        _set_permissions $file || file_error $file "Could not set permissions on '$file'"
+
         local dst=$GRAVEYARD_DIR/`_graveyard_file_name $file`
         log_info "Removing '$file', buried in graveyard as '$dst'"
         if ! mv $file $dst; then


### PR DESCRIPTION
some files might have 000 permissions because of nfs errors and will
be on the production filesystem. the proper way is to handle nfs
errors properly, but it cannot be done on crappy infrastructure.
instead, just set their permissions properly before dealing with them
