### PR TITLE
rsync argo exclude .snapshot directory

### DIFF
--- a/ARGO/rsync.sh
+++ b/ARGO/rsync.sh
@@ -8,4 +8,4 @@ ARGO_SRC=argo
 ARGO_DEST=$OPENDAP_DIR/1/IMOS/opendap/Argo/dac
 ARGO_LOG=$LOG_DIR/argo_rsync.log
 
-rsync --times --delete -rzv $ARGO_SRC_HOST::$ARGO_SRC $ARGO_DEST &>> $LOG_DIR/argo_rsync.log
+rsync --exclude=.snapshot --times --delete -rzv $ARGO_SRC_HOST::$ARGO_SRC $ARGO_DEST &>> $LOG_DIR/argo_rsync.log


### PR DESCRIPTION
ifremer introduced a .snapshot directory which we don't want to sync
