### PR TITLE
fix ftp uploader probing

### DIFF
--- a/lib/common/email.sh
+++ b/lib/common/email.sh
@@ -23,10 +23,14 @@ _get_uploader_ftp() {
     local file=$1; shift
     # an example ftp log line would look like:
     # Wed Jun 24 12:44:22 2015 [pid 3] [user3] OK UPLOAD: Client "1.1.1.1", "/realtime/file.nc", 23103 bytes, 103.59Kbyte/sec
+    # an example file will be:
+    # /var/incoming/facility/realtime/slocum_glider/StormBay20150616/unit286_track_mission.png
+    # for the given file, we'll need to strip '/var/incoming' and then also 'facility'
 
     local log_file
     for log_file in `_log_files_ftp`; do
         local file=`get_relative_path_incoming $file`
+        file=${file#*/} # remove ftp facility (first directory)
         local ftp_user=`test -f $log_file && sudo cat $log_file | grep ", \"/$file\", " | grep " OK UPLOAD: " | tr -s " " | cut -d' ' -f8 | tail -1`
     done
     [ x"$ftp_user" = x ] && return 1

--- a/lib/test/common/shunit2_test.sh
+++ b/lib/test/common/shunit2_test.sh
@@ -195,9 +195,9 @@ user6: user6@email.com
 EOF
     newaliases -oA$email_lookup_file
 
-    assertEquals "user1@email.com" `get_uploader_email /var/incoming/realtime/slocum_glider/StormBay20150616/unit286_track_24hr.png`
-    assertEquals "user2@email.com" `get_uploader_email /var/incoming/realtime/slocum_glider/StormBay20150616/unit286_track_48hr.png`
-    assertEquals "user3@email.com" `get_uploader_email /var/incoming/realtime/slocum_glider/StormBay20150616/unit286_track_mission.png`
+    assertEquals "user1@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit286_track_24hr.png`
+    assertEquals "user2@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit286_track_48hr.png`
+    assertEquals "user3@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit286_track_mission.png`
 
     get_uploader_email /var/incoming/AM/pco2_mooring_data_KANGAROO_5.csv
     assertFalse "should ignore failed uploads" "get_uploader_email /var/incoming/AM/pco2_mooring_data_KANGAROO_5.csv"


### PR DESCRIPTION
the original function needed to first strip the ftp facility.

consider the file:
`/mnt/imos-t4/IMOS/staging/ABOS/SOTS/Pulse/RealTime/file.nc`

its corresponding ftp log line would be:

```
Sun Sep  6 17:12:50 2015 [pid 3] [user] OK UPLOAD: Client "140.79.3.3", "/SOTS/Pulse/RealTime/file.nc", 3729132 bytes, 15586.60Kbyte/sec
```

thus we need to first strip:
- `/mnt/imos-t4/IMOS/staging` - the incoming directory
- `ABOS` - the ftp facility this file was uploaded to
