### PR TITLE
Better matching of who uploaded ftp files

### DIFF
--- a/lib/common/email.sh
+++ b/lib/common/email.sh
@@ -25,18 +25,28 @@ _get_uploader_ftp() {
     # Wed Jun 24 12:44:22 2015 [pid 3] [user3] OK UPLOAD: Client "1.1.1.1", "/realtime/file.nc", 23103 bytes, 103.59Kbyte/sec
     # an example file will be:
     # /var/incoming/facility/realtime/slocum_glider/StormBay20150616/unit286_track_mission.png
-    # for the given file, we'll need to strip '/var/incoming' and then also 'facility'
+    # for the given file, we'll need to strip '/var/incoming' and then:
+    # * facility
+    # * realtime
+    # * slocum_glider
+    # * StormBay20150616
+    # until we reach a basename of a file, then we give up
 
     local log_file
     for log_file in `_log_files_ftp`; do
-        local file=`get_relative_path_incoming $file`
-        file=${file#*/} # remove ftp facility (first directory)
-        local ftp_user=`test -f $log_file && sudo cat $log_file | grep ", \"/$file\", " | grep " OK UPLOAD: " | tr -s " " | cut -d' ' -f8 | tail -1`
-    done
-    [ x"$ftp_user" = x ] && return 1
+        # start stripping the path until we get the best match
+        local trimmed_file=`get_relative_path_incoming $file`
+        while [[ $trimmed_file == *"/"* ]]; do # as long as string contains a slash
+            local ftp_user=`test -f $log_file && sudo cat $log_file | grep ", \"/$trimmed_file\", " | grep " OK UPLOAD: " | tr -s " " | cut -d' ' -f8 | tail -1`
 
-    # user will be in the form of "[user]", so strip the brackets
-    echo ${ftp_user:1:-1}
+            # user will be in the form of "[user]", so strip the brackets
+            [ x"$ftp_user" != x ] && echo ${ftp_user:1:-1} && return 0
+
+            trimmed_file=${trimmed_file#*/} # remove first directory and keep going
+        done
+    done
+
+    return 1
 }
 export -f _get_uploader_ftp
 

--- a/lib/test/common/shunit2_test.sh
+++ b/lib/test/common/shunit2_test.sh
@@ -175,6 +175,7 @@ Wed Jun 24 12:44:21 2015 [pid 3] [user1] OK UPLOAD: Client "1.1.1.1", "/realtime
 Wed Jun 24 12:46:51 2015 [pid 3] CONNECT: Client "1.1.1.4"
 Wed Jun 24 12:44:21 2015 [pid 3] [user2] OK UPLOAD: Client "1.1.1.2", "/realtime/slocum_glider/StormBay20150616/unit286_track_48hr.png", 23090 bytes, 114.94Kbyte/sec
 Wed Jun 24 12:44:22 2015 [pid 3] [user3] OK UPLOAD: Client "1.1.1.3", "/realtime/slocum_glider/StormBay20150616/unit286_track_mission.png", 23103 bytes, 103.59Kbyte/sec
+Wed Jun 24 12:44:22 2015 [pid 3] [user5] OK UPLOAD: Client "1.1.1.3", "/ANFOG/realtime/slocum_glider/StormBay20150616/unit287_track_mission.png", 23103 bytes, 103.59Kbyte/sec
 Wed Jun 24 12:46:51 2015 [pid 3] CONNECT: Client "1.1.1.2"
 Wed Jun 24 12:46:51 2015 [pid 3] CONNECT: Client "1.1.1.3"
 Wed Jun 24 12:55:07 2015 [pid 3] [user4] FAIL UPLOAD: Client "1.1.1.4", "/AM/pco2_mooring_data_KANGAROO_5.csv", 0.00Kbyte/sec
@@ -198,6 +199,7 @@ EOF
     assertEquals "user1@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit286_track_24hr.png`
     assertEquals "user2@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit286_track_48hr.png`
     assertEquals "user3@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit286_track_mission.png`
+    assertEquals "user5@email.com" `get_uploader_email /var/incoming/ANFOG/realtime/slocum_glider/StormBay20150616/unit287_track_mission.png`
 
     get_uploader_email /var/incoming/AM/pco2_mooring_data_KANGAROO_5.csv
     assertFalse "should ignore failed uploads" "get_uploader_email /var/incoming/AM/pco2_mooring_data_KANGAROO_5.csv"


### PR DESCRIPTION
FTP logs only a part of the path that the user has used to upload
a file and that can be different depending on the root directory
that is set for the user. Try best matching by stripping path parts
one by one until a match is found
