### PR TITLE
NETCDF TOOLS update

### DIFF
--- a/lib/common/netcdf-utils.sh
+++ b/lib/common/netcdf-utils.sh
@@ -170,6 +170,39 @@ nc_get_gatt_value() {
 }
 export -f nc_get_gatt_value
 
+# return type of function, float, int, double, byte
+# $1 - netcdf file
+# $2 - variable
+nc_get_variable_type() {
+    local nc_file=$1; shift
+    local var=$1; shift
+    local var_type
+    if nc_has_variable $nc_file $var; then
+        # extract the ncdump type of a variable, float, double, byte, short, long, char . Line example '   double TIME(INSTANCE) ;"
+        var_type="$(ncdump -h $nc_file  | grep -e "^.*$var(.*) ;$" | awk '{print $1;}')"
+
+        if [ "$var_type" == "float" ]; then
+            var_type=f
+        elif [ "$var_type" == "double" ]; then
+            var_type=d
+        elif [ "$var_type" == "byte" ]; then
+            var_type=b
+        elif [ "$var_type" == "short" ]; then
+            var_type=s
+        elif [ "$var_type" == "long" ]; then
+            var_type=l
+        elif [ "$var_type" == "char" ]; then
+            var_type=c
+        else
+            return 1
+        fi
+        echo $var_type
+    else
+        return 1
+    fi
+}
+export -f nc_get_variable_type
+
 #####################
 # PRIVATE FUNCTIONS #
 #####################

--- a/lib/netcdf/netcdf-cf-imos-compliance.sh
+++ b/lib/netcdf/netcdf-cf-imos-compliance.sh
@@ -80,9 +80,9 @@ nc_set_geospatial_vertical_gatt() {
     nc_set_att -a geospatial_vertical_min,global,o,f,$geospatial_vertical_min $nc_file && \
         nc_set_att -a geospatial_vertical_max,global,o,f,$geospatial_vertical_max $nc_file
 
-
-    nc_set_att -a geospatial_vertical_units,global,o,c,"$depth_var:units" $nc_file && \
-        nc_set_att -a geospatial_vertical_positive,global,o,c,"$depth_var:positive" $nc_file 
+    depth_unit="$(nc_get_variable_att $nc_file $depth_var units)"
+    nc_set_att -a geospatial_vertical_units,global,o,c,"$depth_unit" $nc_file && \
+        nc_set_att -a geospatial_vertical_positive,global,o,c,"up" $nc_file
 }
 export -f nc_set_geospatial_vertical_gatt
 
@@ -102,11 +102,14 @@ nc_set_lat_lon_valid_min_max_att() {
         return
     fi
 
-    nc_set_att -a valid_max,LATITUDE,o,f,$valid_lat_max $nc_file
-    nc_set_att -a valid_min,LATITUDE,o,f,$valid_lat_min $nc_file
+    local lat_var_type=`nc_get_variable_type $nc_file LATITUDE`
+    local lon_var_type=`nc_get_variable_type $nc_file LONGITUDE`
 
-    nc_set_att -a valid_max,LONGITUDE,o,f,$valid_lon_max $nc_file
-    nc_set_att -a valid_min,LONGITUDE,o,f,$valid_lon_min $nc_file
+    nc_set_att -a valid_max,LATITUDE,o,$lat_var_type,$valid_lat_max $nc_file
+    nc_set_att -a valid_min,LATITUDE,o,$lat_var_type,$valid_lat_min $nc_file
+
+    nc_set_att -a valid_max,LONGITUDE,o,$lon_var_type,$valid_lon_max $nc_file
+    nc_set_att -a valid_min,LONGITUDE,o,$lon_var_type,$valid_lon_min $nc_file
 }
 export -f nc_set_lat_lon_valid_min_max_att
 
@@ -115,7 +118,8 @@ export -f nc_set_lat_lon_valid_min_max_att
 # $1 - netcdf file
 nc_set_time_valid_min_att() {
     local nc_file=$1; shift
-    nc_set_att -a valid_min,TIME,o,d,0 $nc_file
+    local var_type=`nc_get_variable_type $nc_file TIME`
+    nc_set_att -a valid_min,TIME,o,$var_type,0 $nc_file
 }
 export -f nc_set_time_valid_min_att
 

--- a/lib/test/common/shunit2_test.sh
+++ b/lib/test/common/shunit2_test.sh
@@ -403,6 +403,14 @@ test_nc_del_empty_att() {
     rm $modified_nc_file
 }
 
+# test_nc_get_variable_type
+test_nc_get_variable_type() {
+      assertEquals "NetCDF get time types" "d" "`nc_get_variable_type $NETCDF_FILE_TEST TIME`"
+      assertEquals "NetCDF get latitude types" "f" "`nc_get_variable_type $NETCDF_FILE_TEST LATITUDE`"
+      assertEquals "NetCDF get longitude types" "s" "`nc_get_variable_type $NETCDF_FILE_TEST WIND_FLAG`"
+      assertEquals "NetCDF get history types" "c" "`nc_get_variable_type $NETCDF_FILE_TEST history`"
+}
+
 ##################
 # SETUP/TEARDOWN #
 ##################


### PR DESCRIPTION
- nc_get_variable_type : returns the type of a variable
  this is used to know the type of an attribute which as to be written
  to a variable. Example type of LATITUDE is float, so _FillValue of
  LATITUDE has to be float. Previous version assumed the type, this was
  wrong
- add unit tests for this function
- clean sub functions to use now nc_get_variable_type
