### PR TITLE
generic_handler: add explicit exit if checkers failed

### DIFF
--- a/bin/generic_incoming_handler.sh
+++ b/bin/generic_incoming_handler.sh
@@ -65,7 +65,9 @@ main() {
         regex_filter "$regex" $file || file_error "Did not pass regex filter '$regex'"
     fi
 
-    local tmp_file=`trigger_checkers_and_add_signature $file $backup_recipient $checks`
+    local tmp_file
+    tmp_file=`trigger_checkers_and_add_signature $file $backup_recipient $checks` || \
+        file_error "Failed checks or could not add checker signature. Aborting."
 
     local path_hierarchy
     path_hierarchy=`$DATA_SERVICES_DIR/$path_evaluation_executable $file`


### PR DESCRIPTION
Apparently when capturing the output from a command with ``, the script continues to run even if that command exists with non-zero status. So I was getting messages like this:

```
Nov 10 11:33:50 10-nsp-mel ANMN_QLD_RT: File did not pass all compliance checks, verbose log saved at '/mnt/ebs/log/data-services/ANMN_QLD_RT/IMOS_ANMN-QLD_AETVZ_20150515T005900Z_GBRPPS_FV00_GBRPPS-1505-ADCP-71-GBRPPS-1505-ADCP-71-realtime.nc.20151110-113346.log'
Nov 10 11:33:50 10-nsp-mel ANMN_QLD_RT: Could not process file '/mnt/imos-t4/IMOS/staging/ANMN/QLD/real-time/IMOS_ANMN-QLD_AETVZ_20150515T005900Z_GBRPPS_FV00_GBRPPS-1505-ADCP-71-GBRPPS-1505-ADCP-71-realtime.nc': NetCDF file does not comply with 'imos' conventions
Nov 10 11:33:50 10-nsp-mel ANMN_QLD_RT: Moving '/mnt/imos-t4/IMOS/staging/ANMN/QLD/real-time/IMOS_ANMN-QLD_AETVZ_20150515T005900Z_GBRPPS_FV00_GBRPPS-1505-ADCP-71-GBRPPS-1505-ADCP-71-realtime.nc' -> '/mnt/imos-t4/IMOS/error/ANMN_QLD_RT/IMOS_ANMN-QLD_AETVZ_20150515T005900Z_GBRPPS_FV00_GBRPPS-1505-ADCP-71-GBRPPS-1505-ADCP-71-realtime.nc.20151110-113346'
Nov 10 11:33:52 10-nsp-mel ANMN_QLD_RT: Failed to open NetCDF file /mnt/imos-t4/IMOS/staging/ANMN/QLD/real-time/IMOS_ANMN-QLD_AETVZ_20150515T005900Z_GBRPPS_FV00_GBRPPS-1505-ADCP-71-GBRPPS-1505-ADCP-71-realtime.nc!
Nov 10 11:33:52 10-nsp-mel ANMN_QLD_RT: '/mnt/imos-t4/IMOS/staging/ANMN/QLD/real-time/IMOS_ANMN-QLD_AETVZ_20150515T005900Z_GBRPPS_FV00_GBRPPS-1505-ADCP-71-GBRPPS-1505-ADCP-71-realtime.nc' is not a valid file, aborting.
```

The last two lines come from code that should not be executed if any checks failed.
