### PR TITLE
ANMN_QLD_RT: disable IMOS checks for now

### DIFF
--- a/watch.d/ANMN_QLD_RT
+++ b/watch.d/ANMN_QLD_RT
@@ -4,5 +4,5 @@
       "ANMN/QLD/real-time"
   ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec ANMN/QLD/destPath.py --regex '^IMOS_ANMN-QLD.*realtime.*\.nc$' --checks 'cf imos' --email marty.hidas@utas.edu.au"
+  "execute_params": "--exec ANMN/QLD/destPath.py --regex '^IMOS_ANMN-QLD.*realtime.*\.nc$' --checks 'cf' --email marty.hidas@utas.edu.au"
 }


### PR DESCRIPTION
Some of the files uploaded fail one particular IMOS check which is tricky to fix. Since we're prioritising the pipelines & migration, we'll deal with this later.
