### PR TITLE
rename s3_move_to_production to s3_copy_to_production

### DIFF
--- a/bin/generic_incoming_handler.sh
+++ b/bin/generic_incoming_handler.sh
@@ -80,7 +80,7 @@ main() {
     if [ $push_to_fs == 0 ]; then
         s3_put $tmp_file IMOS/$path_hierarchy && rm -f $file
     elif [ $push_to_fs == 1 ]; then
-        s3_move_to_production $tmp_file IMOS/$path_hierarchy
+        s3_copy_to_production $tmp_file IMOS/$path_hierarchy
         move_to_production_force $tmp_file $OPENDAP_DIR/1 IMOS/opendap/$path_hierarchy && \
             rm -f $file
     fi

--- a/lib/common/util.sh
+++ b/lib/common/util.sh
@@ -292,16 +292,16 @@ file_error_and_report_to_uploader() {
 }
 export -f file_error_and_report_to_uploader
 
-# moves file to s3
+# copies file to s3
 # $1 - file to move
 # $2 - relative path on s3 (object name)
-s3_move_to_production() {
+s3_copy_to_production() {
     local file=$1; shift
     local object_name=$1; shift
     # TODO _s3_put $file $S3_BUCKET/$object_name $object_name
     _s3_put_never_fail $file $S3_BUCKET/$object_name $object_name
 }
-export -f s3_move_to_production
+export -f s3_copy_to_production
 
 # moves file to production filesystem
 # $1 - file to move


### PR DESCRIPTION
This function does not remove the original file, so "copy" is a more accurate name than "move".
