### PR TITLE
ANMN_AM: check for zero-sized files

### DIFF
--- a/ANMN/AM/incoming_handler.sh
+++ b/ANMN/AM/incoming_handler.sh
@@ -63,9 +63,7 @@ handle_csv() {
     local wip_dir="$WIP_DIR/ANMN/AM"
     mkdir -p $wip_dir || file_error "Could not create wip directory '$wip_dir'"
 
-    # copy the csv file to the wip dir with a unique name
-    mkdir -p $wip_dir/tmp/
-    cp -p $file $wip_dir/tmp/`basename $file`.`date +%Y%m%d-%H%M%S`
+    [ -s $file ] || file_error "File is empty"
 
     local netcdf_file
     netcdf_file=`cd $wip_dir && $SCRIPTPATH/rtCO2.py $file` || file_error "Could not generate NetCDF file"


### PR DESCRIPTION
A while ago we had an issue where it looked like some csv files were uploaded with zero size, but we couldn't quite figure out what was going on. In an attempt to debug this, we started copying every single csv file to the wip directory. Since then everything has been running smoothly and the wip dir is filling up, so we may as well stop doing this copy. Instead I've added a check for zero-sized files.
