### PR TITLE
remove tmp dir with hierarchy

### DIFF
--- a/SOOP/SOOP_CO2/incoming_handler.sh
+++ b/SOOP/SOOP_CO2/incoming_handler.sh
@@ -44,7 +44,8 @@ main() {
     done
 
     rm -f $file # remove zip file
-    rmdir $tmp_dir
+    #Dangerous, but necessary, since there might be a hierarchy in the zip file provided
+    rm -rf --preserve-root $tmp_dir
 }
 
 main "$@"


### PR DESCRIPTION
Same as what's done in SOOP-BA. Need to be able to delete tmp dir using rm -rf when hierarchy provided in the zip file
