### PR TITLE
Disable SOOP_TRV processing

### DIFF
--- a/SOOP/SOOP_TRV_aims_download_process/subroutines/destPath.py
+++ b/SOOP/SOOP_TRV_aims_download_process/subroutines/destPath.py
@@ -64,6 +64,8 @@ def createFileHierarchy(netcdfFilePath):
     return relativeNetcdfPath
 
 if __name__== '__main__':
+    exit(1)
+
     # read filename from command line
     if len(sys.argv) < 2:
         print >>sys.stderr, 'No filename specified!'


### PR DESCRIPTION
Talend job gets stuck and bloats the DB. Disabled until this can
be looked at.
