### PR TITLE
Disable AATAMS_SATTAG_DM NetCDF generation

### DIFF
--- a/cron.d/AATAMS_SATTAG_DM
+++ b/cron.d/AATAMS_SATTAG_DM
@@ -2,6 +2,7 @@ SHELL=/bin/bash
 
 MAILTO=laurent.besnard@utas.edu.au
 
-0 0,12 * * * projectofficer AATAMS/AATAMS_sattag_dm/aatams_sattag_dm_main.sh
+# disabled until this is ported to python and operates on a per file basis
+#0 0,12 * * * projectofficer AATAMS/AATAMS_sattag_dm/aatams_sattag_dm_main.sh
 
 0 0,12 * * * projectofficer AATAMS/AATAMS_sattag_dm/lftp_sync.sh


### PR DESCRIPTION
As agreed, this will be disabled until it is ported to python and
can operate on a per-file basis, so it can be hooked to newly
downloaded files.
