### PR TITLE
Pipelines to clean up temp files on error

### DIFF
--- a/lib/common/util.sh
+++ b/lib/common/util.sh
@@ -268,6 +268,8 @@ _file_error() {
     mkdir -p $dst_dir || log_error "Could not create directory '$dst_dir'"
     _mv_retry $file $dst || log_error "Could not move '$file' -> '$dst'"
 
+    [ -v CLEAN_UP_LIST ] && [ -n "$CLEAN_UP_LIST" ] && rm -rf --preserve-root $CLEAN_UP_LIST
+
     exit 1
 }
 export -f _file_error


### PR DESCRIPTION
Several pipelines create temporary files and directories. They may clean these up at the end of the script, but if any errors occur and a `file_error` is called, then that clean up never happens.

This is a suggestion how we could get around this. Any temp file/dir created by an incoming handler script could be added to a list, e.g.

``` bash
export CLEAN_UP_LIST="$CLEAN_UP_LIST $temp_file"
```

Then all items on the list are deleted by any `file_error` function before the process exits.

@danfruehauf Any thoughts on whether this a good idea?
