### PR TITLE
Remove unnecessary python includes

### DIFF
--- a/lib/test/python/test_generate_netcdf_att.py
+++ b/lib/test/python/test_generate_netcdf_att.py
@@ -9,14 +9,11 @@ author : besnard, laurent
 import os
 import sys
 
-LIB_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
-sys.path.insert(0, LIB_DIR)
-
 import unittest
 import textwrap
 from netCDF4 import Dataset
 from tempfile import mkstemp
-from python.generate_netcdf_att import *
+from generate_netcdf_att import *
 
 class TestGenerateNetCDFAtt(unittest.TestCase):
 

--- a/lib/test/python/test_imos_logging.py
+++ b/lib/test/python/test_imos_logging.py
@@ -9,12 +9,9 @@ author : besnard, laurent
 import os
 import sys
 
-LIB_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
-sys.path.insert(0, LIB_DIR)
-
 import unittest
 from tempfile import mkstemp
-from python.imos_logging import IMOSLogging
+from imos_logging import IMOSLogging
 
 class TestImosLogging(unittest.TestCase):
 
@@ -38,11 +35,11 @@ class TestImosLogging(unittest.TestCase):
                 # the assert val is done is non conform way as the entire string
                 # can be checked because of the time information added by the
                 # logger
-                if 'python.imos_logging - INFO - info' in line:
+                if 'imos_logging - INFO - info' in line:
                     self.assertEqual(0, 0)
-                elif 'python.imos_logging - WARNING - warning' in line:
+                elif 'imos_logging - WARNING - warning' in line:
                     self.assertEqual(0, 0)
-                elif 'python.imos_logging - ERROR - error' in line:
+                elif 'imos_logging - ERROR - error' in line:
                     self.assertEqual(0, 0)
                 else:
                     self.assertEqual(1, 0)

--- a/lib/test/python/test_lftp_sync.py
+++ b/lib/test/python/test_lftp_sync.py
@@ -9,15 +9,11 @@ author : besnard, laurent
 import os
 import sys
 
-LIB_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
-sys.path.insert(0, LIB_DIR)
-
 import unittest
 import shutil
 import textwrap
 from tempfile import mkdtemp, mkstemp
-from python.lftp_sync import LFTPSync
-
+from lftp_sync import LFTPSync
 
 class TestGenerateNetCDFAtt(unittest.TestCase):
 

--- a/profile.d/util.sh
+++ b/profile.d/util.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export PYTHONPATH=$DATA_SERVICES_DIR/lib/python
+
 incoming_dir() {
     cd $INCOMING_DIR/"$@"
 }


### PR DESCRIPTION
PYTHONPATH is being set by `test.sh`, so the removed lines are
not required.
