### PR TITLE
Set FAIMMS file limit

### DIFF
--- a/watch.d/FAIMMS.json
+++ b/watch.d/FAIMMS.json
@@ -1,5 +1,7 @@
 {
   "path": [ "FAIMMS" ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec FAIMMS/REALTIME/subroutines/dest_path.py --regex '^IMOS_FAIMMS_[[:alpha:]]{1,2}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?{4,7}_FV0[01]\\.nc.?*' --checks 'cf imos'"
+  "execute_params": "--exec FAIMMS/REALTIME/subroutines/dest_path.py --regex '^IMOS_FAIMMS_[[:alpha:]]{1,2}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?{4,7}_FV0[01]\\.nc.?*' --checks 'cf imos'",
+  "files_warn": "200",
+  "files_crit": "200"
 }


### PR DESCRIPTION
Since FAIMMS is downloading files via cron, there can be an
accummulation of files in the incoming directory. Alert only if
there are more than 200 files there - which probably means
something went wrong.