### PR TITLE
Fix to handle file names containing '.'

### DIFF
--- a/lib/python/file_classifier.py
+++ b/lib/python/file_classifier.py
@@ -45,7 +45,10 @@ class FileClassifier(object):
         """Return the '_'-separated fields in the file name as a list.
         Raise an exception if the number of fields is less than min_fields.
         """
-        just_the_name = os.path.basename(input_file).split('.')[0]  # trim off dirs & extention
+        # trim off dirs & extention
+        basename = os.path.basename(input_file)
+        just_the_name = re.sub('\.\w*$', '', basename)
+
         fields = just_the_name.split('_')
         if len(fields) < min_fields:
             cls._error("'%s' has less than %d fields in file name." % (input_file, min_fields))

--- a/lib/python/test_file_classifier.py
+++ b/lib/python/test_file_classifier.py
@@ -63,6 +63,9 @@ class TestFileClassifier(unittest.TestCase):
         filename = 'IMOS_ANMN-NRS_CDEKOSTUZ_20121113T001841Z_NRSMAI_FV01_Profile-SBE-19plus.nc'
         fields = ['IMOS', 'ANMN-NRS', 'CDEKOSTUZ', '20121113T001841Z', 'NRSMAI', 'FV01', 'Profile-SBE-19plus']
         self.assertEqual(FileClassifier._get_file_name_fields(filename), fields)
+        filename = 'IMOS_ANMN-NRS_ACESTZ_20140507T000300Z_NRSKAI_FV02_NRSKAI-1405-NXIC-CTD-36.12-burst-averaged_END-20141028T230300Z_C-20160202T020400Z.nc'
+        fields = ['IMOS', 'ANMN-NRS', 'ACESTZ', '20140507T000300Z', 'NRSKAI', 'FV02', 'NRSKAI-1405-NXIC-CTD-36.12-burst-averaged', 'END-20141028T230300Z', 'C-20160202T020400Z']
+        self.assertEqual(FileClassifier._get_file_name_fields(filename), fields)
         filename = 'IMOS_ANMN-NRS_20110203_NRSPHB_FV01_LOGSHT.pdf'
         fields = ['IMOS', 'ANMN-NRS', '20110203', 'NRSPHB', 'FV01', 'LOGSHT']
         self.assertEqual(FileClassifier._get_file_name_fields(filename), fields)


### PR DESCRIPTION
Fixes a bug that meant files with '.' in the file name (e.g. "IMOS_ANMN-NRS_ACESTZ_20140507T000300Z_NRSKAI_FV02_NRSKAI-1405-NXIC-CTD-36.12-burst-averaged_END-20141028T230300Z_C-20160202T020400Z.nc") were published with the wrong object id (i.e. wrong "directory").