### PR TITLE
ANMN pipeline improvements

### DIFF
--- a/ANMN/common/dest_path.py
+++ b/ANMN/common/dest_path.py
@@ -11,14 +11,60 @@ Output:
   e.g. IMOS/ANMN/NRS/NRSMAI/Biogeochem_profiles/original_file_name.nc
 
 Assume: (will be checked by handler)
- * File is netCDF
- * File was produced by the Toolbox
+ * File is netCDF, PDF or other allowed format
+ * If NetCDF file, was produced by the Toolbox
  * Site code has been validated in checker (if exists)
 """
 
 import sys
+import os
 from file_classifier import MooringFileClassifier, FileClassifierException
 
+
+class NonNetCDFFileClassifier(MooringFileClassifier):
+
+    @classmethod
+    def _get_extension(cls, input_file):
+        """Return the filename extension, if it exists, '' otherwise."""
+        name_split = input_file.split('.')
+        if len(name_split) > 1:
+            return name_split[-1]
+        else:
+            return ''
+
+    @classmethod
+    def dest_path(cls, input_file):
+        """
+        Destination object path for files other than netCDF files. 
+        Of the form:
+          'IMOS/ANMN/<subfacility>/<site_code>/<data_category>/<input_file_basename>'
+        where
+        <data_category> is "Field_logsheets" for PDF files
+                           "Biogeochem_profiles/non-QC/cnv" for .cnv files
+                           "plots" for .png files
+        """
+        extension = cls._get_extension(input_file)
+        name_fields = cls._get_file_name_fields(input_file)
+
+        dir_list = [cls.PROJECT]
+        dir_list.extend(cls._get_facility(input_file))
+
+        if extension == 'pdf':
+            dir_list.append(name_fields[3])  # site_code
+            dir_list.append('Field_logsheets')
+        elif extension == 'cnv':
+            dir_list.append(name_fields[4])  # site_code
+            dir_list.extend(['Biogeochem_profiles', 'non-QC', 'cnv'])
+        elif extension == 'png':
+            dir_list.append(name_fields[2])  # site_code
+            dir_list.append('plots')
+        else:
+            cls._error("Don't know where to put file '%s' (unhandled extension)" % input_file)
+
+        dir_list.append(os.path.basename(input_file))
+
+        return cls._make_path(dir_list)
+            
 
 
 if __name__=='__main__':
@@ -29,8 +75,13 @@ if __name__=='__main__':
 
     input_path = sys.argv[1]
 
+    if input_path.endswith('.nc'):
+        classifier = MooringFileClassifier
+    else:
+        classifier = NonNetCDFFileClassifier
+
     try:
-        dest_path = MooringFileClassifier.dest_path(input_path)
+        dest_path = classifier.dest_path(input_path)
     except FileClassifierException, e:
         print >>sys.stderr, e
         exit(1)

--- a/ANMN/common/incoming_handler.sh
+++ b/ANMN/common/incoming_handler.sh
@@ -9,6 +9,7 @@ declare -r TIMESTAMP="[0-9]{8}T[0-9]{6}Z"
 declare -r FV="FV0[012]"
 declare -r PRODUCT="[^_]+"
 
+declare -r HANDLED_EXTENSIONS="nc|zip|cnv|pdf|png"
 
 # returns non zero if file does not match regex filter
 # $1 - regex to match with
@@ -26,8 +27,9 @@ handle_netcdf() {
     local file=$1; shift
     local basename_file=`basename $file`
 
-    regex_filter $REGEX $file || \
-        file_error_and_report_to_uploader $BACKUP_RECIPIENT "File name does not match pattern for upload location"
+    local regex="^IMOS_ANMN-${SUBFAC}_${DATACODE}_${TIMESTAMP}_${SITE}_${FV}(_${PRODUCT})?(_END-${TIMESTAMP})?(_C-${TIMESTAMP})?\.nc"
+    regex_filter $regex $file || \
+        file_error_and_report_to_uploader $BACKUP_RECIPIENT "$basename_file has incorrect name or was uploaded to the wrong place"
 
     local dest_path dest_dir
     dest_path=`$SCRIPTPATH/dest_path.py $file` || file_error "Could not determine destination path for file"
@@ -53,6 +55,25 @@ handle_netcdf() {
 }
 
 
+# handle a non-netcdf file for the ANMN facility
+# $1 - file to handle
+# $2 - regex to match against filename
+handle_nonnetcdf() {
+    local file=$1; shift
+    local basename_file=`basename $file`
+    local regex=$1; shift
+
+    regex_filter $regex $file || \
+        file_error_and_report_to_uploader $BACKUP_RECIPIENT "$basename_file has incorrect name or was uploaded to the wrong place"
+
+    local dest_path
+    dest_path=`$SCRIPTPATH/dest_path.py $file` || file_error "Could not determine destination path for file"
+    [ x"$dest_path" = x ] && file_error "Could not determine destination path for file"
+
+    s3_put_no_index $file $dest_path
+}
+
+
 # handle a zip file containing NetCDF files for the ANMN facility
 # $1 - zip file to handle
 handle_zip() {
@@ -66,21 +87,55 @@ handle_zip() {
     local extracted_files=`mktemp --tmpdir=$unzip_dir`
     unzip_file $zipfile $unzip_dir $extracted_files || file_error "Failed to unzip"
 
-    # abort operation if there are any non-NetCDF files in archive
-    # (don't know how to handle them)
-    grep -v '\.nc$' $extracted_files && file_error "Zip file contains non-NetCDF files"
+    # abort operation if there are any files in archive that we don't
+    # know how to handle (don't know how to handle them)
+    grep -Eqv "\.(${HANDLED_EXTENSIONS})\$" $extracted_files && \
+        file_error "Zip file contains unknown file types (only accept .${HANDLED_EXTENSIONS//|/, .})"
 
     # process extracted files
     local n_extracted=`cat $extracted_files | wc -l`
     log_info "Processing $n_extracted extracted files..."
     for file in `cat $extracted_files`; do
-        handle_netcdf $unzip_dir/$file
+        handle_file $unzip_dir/$file
     done
 
     # clean up
     rm -f $zipfile $extracted_files
     rm -rf --preserve-root $unzip_dir
 }
+
+# call the appropriate handler depending on file extension
+# $1 - file to handle
+handle_file() {
+    local file=$1; shift
+    local basename_file=`basename $file`
+
+    local date_or_timestamp="([0-9]{6}|$TIMESTAMP)"  # for non-netcdf files, allow just YYMMDD date
+    local regex
+
+    if has_extension $file "nc"; then
+        handle_netcdf $file
+
+    elif has_extension $file "zip"; then
+        handle_zip $file
+
+    elif has_extension $file "pdf"; then
+        regex="^IMOS_ANMN-${SUBFAC}_${date_or_timestamp}_${SITE}_FV0[01]_LOGSHT"
+        handle_nonnetcdf $file $regex
+
+    elif has_extension $file "cnv"; then
+        regex="^IMOS_ANMN-${SUBFAC}_${DATACODE}_${date_or_timestamp}_${SITE}_FV00_CTDPRO"
+        handle_nonnetcdf $file $regex
+
+    elif has_extension $file "png"; then
+        regex="^IMOS_ANMN-${SUBFAC}_${SITE}_FV01.*_C-${TIMESTAMP}\.png"
+        handle_nonnetcdf $file $regex
+
+    else
+        file_error_and_report_to_uploader $BACKUP_RECIPIENT "File type not accepted ($basename_file)"
+    fi
+}
+
 
 # prints usage and exit
 usage() {
@@ -96,6 +151,7 @@ Options:
 
 # main
 # $1 - file to handle
+# $@ - options
 main() {
     local tmp_getops
     tmp_getops=`getopt -o hs:t:c: --long help,sub-facility:,site:,checks: -- "$@"`
@@ -122,15 +178,10 @@ main() {
 
     [ x"$subfac" = x ] && usage
     [ x"$site" = x ] && usage
-    declare -rg REGEX="^IMOS_ANMN-${subfac}_${DATACODE}_${TIMESTAMP}_${site}_${FV}_${PRODUCT}(_END-${TIMESTAMP})?(_C-${TIMESTAMP})?\.nc"
+    declare -rg SUBFAC="$subfac"
+    declare -rg SITE="$site"
 
-    if has_extension $file "nc"; then
-        handle_netcdf $file
-    elif has_extension $file "zip"; then
-        handle_zip $file
-    else
-        file_error "Not a NetCDF file or a zip file"
-    fi
+    handle_file $file
 }
 
 main "$@"

--- a/ANMN/common/test_dest_path.py
+++ b/ANMN/common/test_dest_path.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"Unit tests for FileClassifier classes"
+
+import os
+import unittest
+from dest_path import NonNetCDFFileClassifier, FileClassifierException
+
+
+class TestNonNetCDFFileClassifier(unittest.TestCase):
+    """Unit tests for ANMN FileClassifier class to handle non-netcdf
+    files.  Other handling of netcdf files is already tested in
+    test_file_classifier.
+
+    Test cases:
+    * PDF logsheet (with 6-digit date or full timestamp)
+    * .cnv file (CTD profile)
+    * .png plots from Toolbox
+
+    Incorrect filenames should be handled before dest_path is called
+    """
+
+    def test_logsheet(self):
+        filename = 'IMOS_ANMN-NRS_100702_NRSPHB_FV00_LOGSHT.pdf'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/NRS/NRSPHB/Field_logsheets')
+        self.assertEqual(dest_filename, filename)
+
+        filename = 'IMOS_ANMN-NRS_20150804T043000Z_NRSDAR_FV01_LOGSHT.pdf'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/NRS/NRSDAR/Field_logsheets')
+        self.assertEqual(dest_filename, filename)
+
+
+    def test_cnv(self):
+        filename = 'IMOS_ANMN-NRS_CTP_090527_NRSNSI_FV00_CTDPRO.cnv'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/NRS/NRSNSI/Biogeochem_profiles/non-QC/cnv')
+        self.assertEqual(dest_filename, filename)
+
+        filename = 'IMOS_ANMN-NRS_CTP_120729T163000Z_NRSDAR_FV00_CTDPRO_01.cnv'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/NRS/NRSDAR/Biogeochem_profiles/non-QC/cnv')
+        self.assertEqual(dest_filename, filename)
+
+        filename = 'IMOS_ANMN-NRS_CDEKOSTUZ_140730_NRSROT_FV00_CTDPRO.cnv'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/NRS/NRSROT/Biogeochem_profiles/non-QC/cnv')
+        self.assertEqual(dest_filename, filename)
+
+    def test_plots(self):
+        filename = 'IMOS_ANMN-WA_WATR20_FV01_WATR20-1502_LINE_TEMP_C-20150820T052407Z.png'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/WA/WATR20/plots')
+        self.assertEqual(dest_filename, filename)
+
+        filename = 'IMOS_ANMN-NRS_NRSYON_FV01_NRSYON-1406_SCATTER_UCUR_C-20150722T055014Z.png'
+        dest_dir, dest_filename = os.path.split(NonNetCDFFileClassifier.dest_path(filename))
+        self.assertEqual(dest_dir, 'IMOS/ANMN/NRS/NRSYON/plots')
+        self.assertEqual(dest_filename, filename)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test.sh
+++ b/test.sh
@@ -9,6 +9,7 @@ TESTS="$TESTS ACORN/current_generator/current_generator_test_unit.py"
 TESTS="$TESTS OceanCurrent/GSLA/shunit2_test.sh"
 
 TESTS="$TESTS ANMN/AM/test_dest_path.py"
+TESTS="$TESTS ANMN/common/test_dest_path.py"
 TESTS="$TESTS ANMN/common/test_previous_versions.py"
 
 TESTS="$TESTS ABOS/common/test_dest_path.py"


### PR DESCRIPTION
* Handle PDF logsheets, CNV files, and PNG plots from Toolbox.
* Unit tests for non-netcdf files.
* Use `$TMPDIR` for unzipping files & clean them up at end.
* Add trigger checkers, selected in watch.d script (none by default).