### PR TITLE
Fix #410

### DIFF
--- a/bin/generic_incoming_handler.sh
+++ b/bin/generic_incoming_handler.sh
@@ -71,7 +71,15 @@ main() {
     local path_hierarchy
     path_hierarchy=`$DATA_SERVICES_DIR/$path_evaluation_executable $file`
     if [ $? -ne 0 ] || [ x"$path_hierarchy" = x ]; then
-        rm -f $tmp_file
+
+        # if the trigger_checkers_and_add_signature() does not return a modified filename then do
+        # not delete $tmp_file which refers to the same resource as $file.
+        # this permits the caller to correctly handle $file as an unprocessed error
+        if [ "$tmp_file" != "$file" ]; then
+            rm -f $tmp_file
+        fi
+
+        # Note, file_error calls exit() which will short-circuit the call to S3_put()
         file_error "Could not evaluate path for '$file' using '$path_evaluation_executable'"
     fi
 


### PR DESCRIPTION
Netcdf file that would silently disappear now routed to the error directory, 
```
root@10-aws-syd:/mnt/ebs/log/data-services$ rm /mnt/ebs/error/SOOP_SST/*
root@10-aws-syd:/mnt/ebs/log/data-services$ ls /mnt/ebs/error/SOOP_SST/
root@10-aws-syd:/mnt/ebs/log/data-services$ cp /mnt/ebs/wip/SOOP/SOOP_XBT_ASF_SST/data_unsorted/ASF_SST/ship/2016/IMOS_SOOP-SST_T_20160223T000300Z_VRDU8_FV01_C-20160224T001314Z.nc $INCOMING_DIR/SOOP/SST
root@10-aws-syd:/mnt/ebs/log/data-services$ ls /mnt/ebs/error/SOOP_SST/                                                                     
IMOS_SOOP-SST_T_20160223T000300Z_VRDU8_FV01_C-20160224T001314Z.nc.20160420-092036
root@10-aws-syd:/mnt/ebs/log/data-services$ 
```