### PR TITLE
Turn off CF checks for ANMN_NSW

### DIFF
--- a/watch.d/ANMN_NSW.json
+++ b/watch.d/ANMN_NSW.json
@@ -1,5 +1,5 @@
 {
   "path": [ "ANMN/NSW" ],
   "execute": "ANMN/common/incoming_handler.sh",
-  "execute_params": "--sub-facility 'NSW' --site '(BMP070|BMP090|BMP120|CH070|CH100|JB070|PH025|PH050|PH100|PH125|PH140|SYD100|SYD140)' --checks 'cf'"
+  "execute_params": "--sub-facility 'NSW' --site '(BMP070|BMP090|BMP120|CH070|CH100|JB070|PH025|PH050|PH100|PH125|PH140|SYD100|SYD140)'"
 }


### PR DESCRIPTION
I need to temporarily turn this off to publish some files in the incoming backlog that don't pass the checkers.