### PR TITLE
Acorn current generator update

### DIFF
--- a/ACORN/current_generator/acorn_utils.py
+++ b/ACORN/current_generator/acorn_utils.py
@@ -104,7 +104,7 @@ def is_vector(f):
 def is_qc(f):
     return get_file_version(f) == "FV01"
 
-def is_current(f):
+def is_hourly(f):
     return get_file_type(f) == "1-hour-avg"
 
 def days_since_1950(timestamp):

--- a/ACORN/current_generator/current_generator.py
+++ b/ACORN/current_generator/current_generator.py
@@ -24,7 +24,7 @@ def current_from_file(input_file, dest_dir):
         return wera.generate_current_from_radial_file(input_file, dest_dir)
     elif acorn_utils.is_vector(input_file):
         return codar.generate_current_from_vector_file(input_file, dest_dir)
-    elif acorn_utils.is_current(input_file):
+    elif acorn_utils.is_hourly(input_file):
         # We actually get the site, not the station, but it's the same part of
         # the file
         site = acorn_utils.get_station(input_file)

--- a/ACORN/current_generator/wera.py
+++ b/ACORN/current_generator/wera.py
@@ -283,7 +283,11 @@ def generate_current_from_radial_file(radialFile, dest_dir):
     timestamp = acorn_utils.get_timestamp(radialFile)
     qc = acorn_utils.is_qc(radialFile)
 
-    return generate_current(site, timestamp, qc, dest_dir)
+    if qc:
+        logging.info("We do nothing, ACORN UWA is in charge of generating hourly vector currents from '%s'" % radialFile)
+        return acorn_utils.ACORNError.SUCCESS
+    else:
+        return generate_current(site, timestamp, qc, dest_dir)
 
 def generate_current(site, timestamp, qc, dest_dir):
     timestamp = acorn_utils.get_current_timestamp(timestamp)


### PR DESCRIPTION
We don't need to create hourly averaged vector current files from received FV01 radials, UWA ACORN is now in charge of such processing.