### PR TITLE
ANMN_SA: allow data from any site code, including NRS

### DIFF
--- a/watch.d/ANMN_SA.json
+++ b/watch.d/ANMN_SA.json
@@ -1,5 +1,5 @@
 {
   "path": [ "ANMN/SA" ],
   "execute": "ANMN/common/incoming_handler.sh",
-  "execute_params": "--sub-facility 'SA' --site '(SAM1DS|SAM2CP|SAM3MS|SAM4CY|SAM5CB|SAM6IS|SAM7DS|SAM8SG)' --checks 'cf'"
+  "execute_params": "--sub-facility '(SA|NRS)' --site '[A-Z][A-Za-z0-9]+' --checks 'cf'"
 }


### PR DESCRIPTION
This is necessary because Paul needs to upload CTD profiles from all the sites they sample in SA and they have ~300 different site codes.