### PR TITLE
ABOS_DA: add new site & tweak error message

### DIFF
--- a/ABOS/common/incoming_handler.sh
+++ b/ABOS/common/incoming_handler.sh
@@ -29,7 +29,7 @@ handle_netcdf() {
     local basename_file=`basename $file`
 
     regex_filter $REGEX $file || \
-        file_error_and_report_to_uploader $BACKUP_RECIPIENT "File '$file' has incorrect name or was uploaded to the wrong directory"
+        file_error_and_report_to_uploader $BACKUP_RECIPIENT "File '$basename_file' has incorrect name or was uploaded to the wrong directory"
 
     local tmp_file
     tmp_file=`trigger_checkers_and_add_signature $file $BACKUP_RECIPIENT $CHECKS` || return 1

--- a/watch.d/ABOS_DA.json
+++ b/watch.d/ABOS_DA.json
@@ -1,5 +1,5 @@
 {
   "path": [ "ABOS/DA" ],
   "execute": "ABOS/common/incoming_handler.sh",
-  "execute_params": "--sub-facility 'DA' --site '(EAC1|EAC2|EAC3|EAC4|EAC5|ITFOMB|ITFTIN|ITFTSL|POLYNYA1|POLYNYA2|TOTTEN1|TOTTEN2|TOTTEN3)' --checks 'cf'"
+  "execute_params": "--sub-facility 'DA' --site '(EAC1|EAC2|EAC3|EAC4|EAC5|ITFOMB|ITFTIN|ITFTSL|ITFTNS|POLYNYA1|POLYNYA2|TOTTEN1|TOTTEN2|TOTTEN3)' --checks 'cf'"
 }


### PR DESCRIPTION
* add ITFTNS as a new site for ABOS_DA pipeline
* ABOS/common handler: only report filename (not temp path) when file fails regexp