### PR TITLE
Checked $S3CMD is not mocked version if using mime

### DIFF
--- a/lib/common/s3.sh
+++ b/lib/common/s3.sh
@@ -72,18 +72,20 @@ s3_put_no_index_keep_file() {
 
     test -f $src || file_error "Not a regular file"
 
-    if [[ $src =~ \.gz$ ]]; then
-        mime='application/gzip'
-    elif [[ $src =~ \.nc$ ]]; then
-        mime='application/octet-stream'
-    elif [[ $src =~ \.csv$ ]]; then
-        mime='text/csv'
-    elif [[ $src =~ \.pdf$ ]]; then
-        mime='application/pdf'
-    elif [[ $src =~ \.png$ ]]; then
-        mime='image/png'
-    elif [[ $src =~ \.jpg$ ]]; then
-        mime='image/jpeg'
+    if echo $S3CMD | grep -v -q mocked; then
+        if [[ $src =~ \.gz$ ]]; then
+            mime='application/gzip'
+        elif [[ $src =~ \.nc$ ]]; then
+            mime='application/octet-stream'
+        elif [[ $src =~ \.csv$ ]]; then
+            mime='text/csv'
+        elif [[ $src =~ \.pdf$ ]]; then
+            mime='application/pdf'
+        elif [[ $src =~ \.png$ ]]; then
+            mime='image/png'
+        elif [[ $src =~ \.jpg$ ]]; then
+            mime='image/jpeg'
+        fi
     fi
 
     log_info "Moving '$src' -> '$dst'"


### PR DESCRIPTION
related to https://github.com/aodn/data-services/issues/527

The bug was getting annoying as a working pipeline would fail after indexing on the POBOX. The mocked version of S3CMD doesn't handle MIMEs. 

I don't really like this PR since it's patchy. My opinion is that this commit https://github.com/aodn/data-services/commit/184f26679ff92ae8c05c0f01b1b226e164f51e88 should not have been here in the first place.

So it's kind of patching the patch. 

@lwgordonimos I'd really like your opinion on this