### PR TITLE
Change vocab xml url to content

### DIFF
--- a/lib/python/platform_code_vocab.py
+++ b/lib/python/platform_code_vocab.py
@@ -26,8 +26,8 @@ def platform_type_uris_by_category():
     retrieves a list of platform category and their narrowMatch url type which
     defines their category
     """
-    # platform_cat_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform-category/aodn_aodn-platform-category-vocabulary.rdf'
-    platform_cat_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/112/aodn_aodn-platform-category-vocabulary_version-1-0.rdf'
+    platform_cat_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform-category/aodn_aodn-platform-category-vocabulary.rdf'
+    # platform_cat_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/112/aodn_aodn-platform-category-vocabulary_version-1-0.rdf'
     response               = urllib2.urlopen(platform_cat_vocab_url)
     html                   = response.read()
     root                   = ET.fromstring(html)
@@ -67,8 +67,8 @@ def platform_altlabels_per_preflabel(category_name=None):
         platform_altlabels_per_preflabel('Vessel')
     """
 
-    # platform_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform/aodn_aodn-platform-vocabulary.rdf'
-    platform_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/373/aodn_aodn-platform-vocabulary_version-1-3.rdf'
+    platform_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform/aodn_aodn-platform-vocabulary.rdf'
+    # platform_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/373/aodn_aodn-platform-vocabulary_version-1-3.rdf'
     response           = urllib2.urlopen(platform_vocab_url)
     html               = response.read()
     root               = ET.fromstring(html)


### PR DESCRIPTION
 * reason : since Nat is the only one creating the new vocab version and
   pushing the xml file to content, it is more logical to use the
   content url