### PR TITLE
Fix bug in burst-average product affecting standard deviation variables

### DIFF
--- a/ANMN/burst_averaged_product/burst_average.py
+++ b/ANMN/burst_averaged_product/burst_average.py
@@ -197,7 +197,7 @@ def burst_average_data(time_values, var_values, var_qc_exclusion):
                  'var_mean':    var_mean_burst,
                  'var_min':     var_min_burst,
                  'var_max':     var_max_burst,
-                 'var_sd':      var_max_burst,
+                 'var_sd':      var_sd_burst,
                  'var_num_obs': var_num_obs_burst}
 
     return burst_var


### PR DESCRIPTION
Looks like a copy-paste error. The standard deviation variables were being filled with the same burst max values!