### PR TITLE
Update pipelines to specify IMOS-1.3 conventions

### DIFF
--- a/AATAMS/AATAMS_sattag_nrt/incoming_handler.sh
+++ b/AATAMS/AATAMS_sattag_nrt/incoming_handler.sh
@@ -12,7 +12,7 @@ netcdf_check_added_files() {
     # run checker on files
     local file
     for file in `cat $tmp_files_added`; do
-        if ! check_netcdf_cf $file; then
+        if ! netcdf_checker -t=cf $file; then
             log_error "'$file' is not a valid NetCDF file"
             let retval=$retval+1
         fi

--- a/ANFOG/DM/incoming_handler.sh
+++ b/ANFOG/DM/incoming_handler.sh
@@ -48,7 +48,7 @@ get_path_for_netcdf() {
 # $1 - netcdf file
 handle_netcdf_file() {
     local file=$1; shift
-    local checks='cf imos'
+    local checks='cf imos:1.3'
 
     log_info "Handling ANFOG DM netcdf file '$file'"
 

--- a/ANFOG/RT/incoming_handler.sh
+++ b/ANFOG/RT/incoming_handler.sh
@@ -38,7 +38,7 @@ handle_zip_file() {
 
     check_netcdf  $tmp_nc_file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "Not a valid NetCDF file"
 #    netcdf_checker -t=cf   $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not CF compliant"
-#    netcdf_checker -t=imos $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
+#    netcdf_checker -t=imos:1.3 $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
 
     local platform=`get_platform $tmp_nc_file`
     local mission_id=`get_mission_id $tmp_nc_file`

--- a/ANFOG/RT/incoming_handler.sh
+++ b/ANFOG/RT/incoming_handler.sh
@@ -37,8 +37,8 @@ handle_zip_file() {
     local tmp_nc_file=`make_writable_copy $tmp_dir/$nc_file`
 
     check_netcdf  $tmp_nc_file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "Not a valid NetCDF file"
-#    check_netcdf_cf   $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not CF compliant"
-#    check_netcdf_imos $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
+#    netcdf_checker -t=cf   $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not CF compliant"
+#    netcdf_checker -t=imos $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
 
     local platform=`get_platform $tmp_nc_file`
     local mission_id=`get_mission_id $tmp_nc_file`

--- a/ANMN/AM/incoming_handler.sh
+++ b/ANMN/AM/incoming_handler.sh
@@ -25,7 +25,7 @@ handle_netcdf() {
     is_anmn_am_file $file || \
         file_error_and_report_to_uploader $BACKUP_RECIPIENT "Not an Acidification Moorings file"
 
-    local checks='cf imos'
+    local checks='cf imos:1.3'
     local tmp_file
     tmp_file=`trigger_checkers_and_add_signature $file $BACKUP_RECIPIENT $checks` || return 1
 

--- a/SOOP/SOOP_BA/incoming_handler.sh
+++ b/SOOP/SOOP_BA/incoming_handler.sh
@@ -98,7 +98,7 @@ main() {
 
     check_netcdf  $tmp_nc_file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "Not a valid NetCDF file"
 #    netcdf_checker -t=cf   $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not CF compliant"
-#    netcdf_checker -t=imos $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
+#    netcdf_checker -t=imos:1.3 $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
 
     log_info "Processing '$tmp_nc_file'"
     local path

--- a/SOOP/SOOP_BA/incoming_handler.sh
+++ b/SOOP/SOOP_BA/incoming_handler.sh
@@ -97,8 +97,8 @@ main() {
     fi
 
     check_netcdf  $tmp_nc_file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "Not a valid NetCDF file"
-#    check_netcdf_cf   $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not CF compliant"
-#    check_netcdf_imos $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
+#    netcdf_checker -t=cf   $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not CF compliant"
+#    netcdf_checker -t=imos $file || file_error_and_report_to_uploader $BACKUP_RECIPIENT "File is not IMOS compliant"
 
     log_info "Processing '$tmp_nc_file'"
     local path

--- a/SOOP/SOOP_CO2/incoming_handler.sh
+++ b/SOOP/SOOP_CO2/incoming_handler.sh
@@ -56,7 +56,7 @@ main() {
     local tmp_nc_file=`make_writable_copy $tmp_dir/$nc_file`
 
     local tmp_nc_file_with_sig
-    local checks='cf imos'
+    local checks='cf imos:1.3'
 
     if is_imos_soop_co2_file $tmp_nc_file; then
         tmp_nc_file_with_sig=`trigger_checkers_and_add_signature $tmp_nc_file $BACKUP_RECIPIENT $checks`

--- a/SOOP/SOOP_TMV/incoming_handler.sh
+++ b/SOOP/SOOP_TMV/incoming_handler.sh
@@ -13,7 +13,7 @@ is_soop_tmv_file() {
 # $1 - file to handle
 main() {
     local nc_file=$1; shift
-    local checks='cf imos'
+    local checks='cf imos:1.3'
     log_info "Handling SOOP TMV file '$nc_file'"
 
     is_soop_tmv_file $nc_file || file_error "Not a SOOP TMV file"

--- a/lib/common/netcdf-check.sh
+++ b/lib/common/netcdf-check.sh
@@ -49,38 +49,6 @@ check_netcdf() {
 }
 export -f check_netcdf
 
-# checks a netcdf file for CF compliance
-# $1 - netcdf file to check
-check_netcdf_cf() {
-    local file=$1; shift
-    netcdf_checker $file --test=cf
-}
-export -f check_netcdf_cf
-
-# checks a netcdf file for IMOS compliance
-# $1 - netcdf file to check
-check_netcdf_imos() {
-    local file=$1; shift
-    netcdf_checker $file --test=imos
-}
-export -f check_netcdf_imos
-
-# checks a netcdf file for an IMOS facility compliance
-# $1 - netcdf file to check
-# $2 - facility specific plugin
-check_netcdf_facility() {
-    local file=$1; shift
-    local facility=$1; shift
-    netcdf_checker $file --test=$facility
-}
-export -f check_netcdf_facility
-
-# return the path where the compliance checker code is checked out
-_get_checker_code_dir() {
-    dirname `readlink -f $NETCDF_CHECKER`
-}
-export -f _get_checker_code_dir
-
 # add/update global attributes in a netCDF file to record the fact
 # that it has passed the checker.
 #   - compliance_checker_version (e.g. "2.2.0")
@@ -131,8 +99,7 @@ trigger_checkers() {
 
     local check_suite
     for check_suite in "$@"; do
-        local checker_function="check_netcdf_${check_suite}"
-        $checker_function $file || \
+        netcdf_checker $file --test=$check_suite || \
             $error_handler "NetCDF file does not comply with '${check_suite}' conventions"
     done
 }

--- a/watch.d/ANMN_NRS_AIMS.json
+++ b/watch.d/ANMN_NRS_AIMS.json
@@ -1,5 +1,5 @@
 {
   "path": [ "ANMN/AIMS_NRS" ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec ANMN/NRS_AIMS/REALTIME/dest_path.py --regex '^IMOS_ANMN_[[:alpha:]]{1}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?*\\.nc.?*' --checks 'cf imos' --email laurent.besnard@utas.edu.au"
+  "execute_params": "--exec ANMN/NRS_AIMS/REALTIME/dest_path.py --regex '^IMOS_ANMN_[[:alpha:]]{1}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?*\\.nc.?*' --checks 'cf imos:1.3' --email laurent.besnard@utas.edu.au"
 }

--- a/watch.d/ANMN_NRS_RT.json
+++ b/watch.d/ANMN_NRS_RT.json
@@ -1,5 +1,5 @@
 {
   "path": [ "ANMN/NRS/real-time" ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec ANMN/NRSrealtime/destPath.py --regex '^IMOS_ANMN-NRS.*realtime.*\\.nc$' --checks 'cf imos' --email marty.hidas@utas.edu.au"
+  "execute_params": "--exec ANMN/NRSrealtime/destPath.py --regex '^IMOS_ANMN-NRS.*realtime.*\\.nc$' --checks 'cf imos:1.3' --email marty.hidas@utas.edu.au"
 }

--- a/watch.d/FAIMMS.json
+++ b/watch.d/FAIMMS.json
@@ -1,7 +1,7 @@
 {
   "path": [ "FAIMMS" ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec FAIMMS/REALTIME/dest_path.py --regex '^IMOS_FAIMMS_[[:alpha:]]{1,2}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?{4,7}_FV0[01]\\.nc.?*' --checks 'cf imos'",
+  "execute_params": "--exec FAIMMS/REALTIME/dest_path.py --regex '^IMOS_FAIMMS_[[:alpha:]]{1,2}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?{4,7}_FV0[01]\\.nc.?*' --checks 'cf imos:1.3'",
   "files_warn": "200",
   "files_crit": "200"
 }

--- a/watch.d/SOOP_TRV.json
+++ b/watch.d/SOOP_TRV.json
@@ -1,5 +1,5 @@
 {
   "path": [ "SOOP/TRV" ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec SOOP/SOOP_TRV/dest_path.py --regex '^IMOS_SOOP-TRV_[[:alpha:]]{1,2}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?{4,7}_FV0[01]_END-[[:digit:]]{8}T[[:digit:]]{6}Z.*\\.nc$' --checks 'cf imos'"
+  "execute_params": "--exec SOOP/SOOP_TRV/dest_path.py --regex '^IMOS_SOOP-TRV_[[:alpha:]]{1,2}_[[:digit:]]{8}T[[:digit:]]{6}Z_.?{4,7}_FV0[01]_END-[[:digit:]]{8}T[[:digit:]]{6}Z.*\\.nc$' --checks 'cf imos:1.3'"
 }

--- a/watch.d/SRS_OC_LJCO.json
+++ b/watch.d/SRS_OC_LJCO.json
@@ -1,5 +1,5 @@
 {
   "path": [ "SRS/OC/LJCO" ],
   "execute": "bin/generic_incoming_handler.sh",
-  "execute_params": "--exec SRS/LJCO/dest_path.py --regex '^IMOS_SRS-OC-LJCO_.?*_[[:digit:]]{8}T[[:digit:]]{6}Z_SRC_FV0[12]_(ACS|EcoTriplet|BB9|HyperOCR|WQM).?*\\.nc' --checks 'cf imos'"
+  "execute_params": "--exec SRS/LJCO/dest_path.py --regex '^IMOS_SRS-OC-LJCO_.?*_[[:digit:]]{8}T[[:digit:]]{6}Z_SRC_FV0[12]_(ACS|EcoTriplet|BB9|HyperOCR|WQM).?*\\.nc' --checks 'cf imos:1.3'"
 }


### PR DESCRIPTION
This can be merged now. The only noticeable effect it should have is that the checker signature attributes added to each file that passes will now say "imos:1.3" instead of "imos".

This needs to be done before we deploy the imos:1.4 checker.