### PR TITLE
Fix IMOS-1.4 checker unittests

### DIFF
--- a/lib/cc_plugin_imos/cc_plugin_imos/tests/test_imos.py
+++ b/lib/cc_plugin_imos/cc_plugin_imos/tests/test_imos.py
@@ -928,6 +928,11 @@ class TestIMOS1_4(TestIMOS1_3):
         self.assertEqual(len(failed_att), len(bad_att))
         self.assertEqual(set(failed_att), set(bad_att))
 
+    def test_check_acknowledgement(self):
+        # no longer have a separate method for this, covered by
+        # check_mandatory_global_attributes
+        pass
+
 
 
 ################################################################################


### PR DESCRIPTION
*Executive summary:* please merge this so that the unittests pass and the IMOS-1.4 checker plugin can be deployed.

*The long story:* I was pretty sure all the unittests were passing before I put up my PR for the IMOS-1.4 checker ( #561), but it turns out I missed one. The 1.3 checker had a separate method called `check_acknowledgement`, and an associated unittest. This became redundant in 1.4. However, because all the 1.3 unittests are inherited by 1.4 (as all of them should still apply, unless otherwise stated), I need to explicitly skip this test for 1.4