### PR TITLE
IMOS checker: skip test that fails if netcdf library is too old

### DIFF
--- a/lib/cc_plugin_imos/cc_plugin_imos/tests/test_imos.py
+++ b/lib/cc_plugin_imos/cc_plugin_imos/tests/test_imos.py
@@ -10,6 +10,7 @@ import unittest
 import os
 import re
 import numpy as np
+import netCDF4
 
 
 
@@ -848,6 +849,8 @@ class TestIMOS1_4(TestIMOS1_3):
         self.assertEqual(len(failed_var), 4)
         self.assertEqual(set(failed_var), set(['data_variable', 'random_data']))
 
+    @unittest.skipUnless(netCDF4.__netcdf4libversion__ >= '4.3',
+                         'requires netCDF4 library version >= 4.3')
     def test_check_fill_value(self):
         ret_val = self.imos.check_fill_value(self.bad_coords_dataset)
         self.assertEqual(len(ret_val), 2)


### PR DESCRIPTION
The unittests rely on netCDF files generated from CDL (at test setup time) using `ncgen`, which is part of the standard netcdf library. Unfortunately in older versions (e.g. what we have on our Jenkins build, RC and prod environments) the generated netCDF can be slightly different. In particular `NaN` values are not handled properly. The `test_check_fill_value` test is specifically relying on a test file having an NaN-valued attribute, and therefore fails if that file was generated by an older version of `ncgen`.

I've made the skip conditional, so that we can still run this test on another machine with newer libraries. I don't actually know what the minimum netCDF library version is for this test to work, but 4.1.1 (as we have in Jenkins/RC/prod) is definitely too early, and 4.3.3.1 (which I have on my laptop) is ok.