### PR TITLE
Code cleaning - use PYTHONPATH env for python imports

### DIFF
--- a/AATAMS/AATAMS_sattag_nrt/aatams_nrt.py
+++ b/AATAMS/AATAMS_sattag_nrt/aatams_nrt.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
-from datetime import datetime
-from dest_path import create_file_hierarchy
-from generate_netcdf_att import *
-from imos_logging import IMOSLogging
-from lftp_sync import LFTPSync
-from netCDF4 import Dataset, date2num
-from tendo import singleton
-from util import list_files_recursively
 import argparse
 import csv
 import gzip
 import os
 import shutil
 import time
+from datetime import datetime
 
+from netCDF4 import Dataset, date2num
+from tendo import singleton
+
+from dest_path import create_file_hierarchy
+from generate_netcdf_att import *
+from imos_logging import IMOSLogging
+from lftp_sync import LFTPSync
+from util import list_files_recursively
 
 OUTPUT_DIR = os.path.join(os.environ['WIP_DIR'], 'AATAMS', 'AATAMS_sattag_nrt')
 

--- a/AATAMS/AATAMS_sattag_nrt/dest_path.py
+++ b/AATAMS/AATAMS_sattag_nrt/dest_path.py
@@ -4,8 +4,11 @@ Returns the relative path of a AATAMS NRT NetCDF file
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-import os, sys
+import os
+import sys
+
 from netCDF4 import Dataset
+
 
 def create_file_hierarchy(netcdf_file_path):
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')

--- a/AATAMS/QC_CTD/dest_path.py
+++ b/AATAMS/QC_CTD/dest_path.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+
 from netCDF4 import Dataset
 
 

--- a/ABOS/ASFS/dest_path.py
+++ b/ABOS/ASFS/dest_path.py
@@ -15,10 +15,11 @@ Assume: (will be checked by handler)
  * Site code has been validated in checker (if exists)
 """
 
-import sys
 import os
+import sys
 from datetime import datetime, timedelta
-from file_classifier import MooringFileClassifier, FileClassifierException
+
+from file_classifier import FileClassifierException, MooringFileClassifier
 
 
 class SOFSFileClassifier(MooringFileClassifier):

--- a/ABOS/ASFS/test_dest_path.py
+++ b/ABOS/ASFS/test_dest_path.py
@@ -2,11 +2,12 @@
 "Unit tests for FileClassifier classes"
 
 import os
-import unittest
-from test_file_classifier import make_test_file
-from dest_path import SOFSFileClassifier, FileClassifierException
-from tempfile import mkdtemp
 import shutil
+import unittest
+from tempfile import mkdtemp
+
+from dest_path import FileClassifierException, SOFSFileClassifier
+from test_file_classifier import make_test_file
 
 
 class TestSOFSFileClassifier(unittest.TestCase):

--- a/ABOS/common/dest_path.py
+++ b/ABOS/common/dest_path.py
@@ -15,9 +15,10 @@ Assume: (will be checked by handler)
  * Site code has been validated in checker (if exists)
 """
 
-import sys
 import os
-from file_classifier import MooringFileClassifier, FileClassifierException
+import sys
+
+from file_classifier import FileClassifierException, MooringFileClassifier
 
 
 class ABOSFileClassifier(MooringFileClassifier):

--- a/ABOS/common/test_dest_path.py
+++ b/ABOS/common/test_dest_path.py
@@ -2,11 +2,12 @@
 "Unit tests for FileClassifier classes"
 
 import os
-import unittest
-from test_file_classifier import make_test_file
-from dest_path import ABOSFileClassifier, FileClassifierException
-from tempfile import mkdtemp
 import shutil
+import unittest
+from tempfile import mkdtemp
+
+from dest_path import ABOSFileClassifier, FileClassifierException
+from test_file_classifier import make_test_file
 
 
 class TestABOSFileClassifier(unittest.TestCase):

--- a/ACORN/current_generator/acorn_constants.py
+++ b/ACORN/current_generator/acorn_constants.py
@@ -1,9 +1,10 @@
 #!/usr/bin/python
 
-import numpy as np
-import os
 import copy
+import os
 from string import Template
+
+import numpy as np
 
 HTTP_BASE = "http://imos-data.aodn.org.au" # TODO
 

--- a/ACORN/current_generator/acorn_qc.py
+++ b/ACORN/current_generator/acorn_qc.py
@@ -1,9 +1,12 @@
 #!/usr/bin/python
 
 import logging
+
 import numpy as np
+
 import acorn_constants
 import acorn_utils
+
 
 """
 The station_data struct is something that looks like:
@@ -241,4 +244,3 @@ def gdop_masking(station_data, gdop, qc_key, qc_mode=False, bad_gdop=20, suspici
         qc_matrix[np.isnan(qc_matrix)] = default_qc_value
 
         station_data[station][qc_key] = qc_matrix
-

--- a/ACORN/current_generator/acorn_utils.py
+++ b/ACORN/current_generator/acorn_utils.py
@@ -1,13 +1,17 @@
 #!/usr/bin/python
 
-import os, sys
+import logging
+import os
+import sys
 import urllib2
+from datetime import datetime, timedelta
 from multiprocessing import Pool
 from string import Template
+
 import numpy as np
-from datetime import datetime, timedelta
+
 import acorn_constants
-import logging
+
 
 class Enum(set):
     def __getattr__(self, name):

--- a/ACORN/current_generator/codar.py
+++ b/ACORN/current_generator/codar.py
@@ -1,16 +1,19 @@
 #!/usr/bin/python
 
-import os, sys
-import numpy as np
-import tempfile
-import shutil
-from datetime import datetime, timedelta
-from netCDF4 import Dataset
 import logging
+import os
+import shutil
+import sys
+import tempfile
+from datetime import datetime, timedelta
+
+import numpy as np
+from netCDF4 import Dataset
 
 import acorn_constants
-import acorn_utils
 import acorn_qc
+import acorn_utils
+
 
 class Util:
     @staticmethod

--- a/ACORN/current_generator/current_generator.py
+++ b/ACORN/current_generator/current_generator.py
@@ -1,18 +1,19 @@
 #!/usr/bin/python
 
-import os, sys
-import urllib2
-import numpy as np
-from datetime import datetime, timedelta
-from netCDF4 import Dataset
-import logging
 import argparse
+import logging
+import os
+import sys
+import urllib2
+from datetime import datetime, timedelta
+
+import numpy as np
+from netCDF4 import Dataset
 
 import acorn_constants
 import acorn_utils
-
-import wera
 import codar
+import wera
 
 root = logging.getLogger()
 root.setLevel(logging.DEBUG)

--- a/ACORN/current_generator/current_generator_test_unit.py
+++ b/ACORN/current_generator/current_generator_test_unit.py
@@ -1,16 +1,17 @@
 #!/usr/bin/python
 
-import unittest
-import numpy as np
-from datetime import datetime
 import logging
-import current_generator
-import acorn_constants
-import acorn_utils
-import acorn_qc
+import unittest
+from datetime import datetime
 
-import wera
+import numpy as np
+
+import acorn_constants
+import acorn_qc
+import acorn_utils
 import codar
+import current_generator
+import wera
 
 logging.getLogger().setLevel(logging.ERROR)
 

--- a/ACORN/current_generator/filename_generator.py
+++ b/ACORN/current_generator/filename_generator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
-from datetime import datetime, timedelta
 import argparse
+from datetime import datetime, timedelta
 
 import acorn_utils
 

--- a/ACORN/current_generator/wera.py
+++ b/ACORN/current_generator/wera.py
@@ -1,16 +1,19 @@
 #!/usr/bin/python
 
-import os, sys
-import numpy as np
-import tempfile
-import shutil
-from netCDF4 import Dataset
 import logging
+import os
+import shutil
+import sys
+import tempfile
 import warnings
 
+import numpy as np
+from netCDF4 import Dataset
+
 import acorn_constants
-import acorn_utils
 import acorn_qc
+import acorn_utils
+
 
 class Util:
     @staticmethod

--- a/ANMN/AM/dest_path.py
+++ b/ANMN/AM/dest_path.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+
 from file_classifier import FileClassifier, FileClassifierException
 
 

--- a/ANMN/AM/previousVersions.py
+++ b/ANMN/AM/previousVersions.py
@@ -4,11 +4,12 @@
 # NetCDF file on the opendap filesystem.
 
 
-import os
-import sys
-import re
-from netCDF4 import Dataset
 import argparse
+import os
+import re
+import sys
+
+from netCDF4 import Dataset
 
 
 def previousVersions(new_file, dest_path):

--- a/ANMN/AM/rtCO2.py
+++ b/ANMN/AM/rtCO2.py
@@ -3,14 +3,15 @@
 # Python module to process real-time CO2 data from ANMN acidification moorings.
 
 
-import numpy as np
 import os
 import sys
-from datetime import datetime
 from collections import OrderedDict
-from dataUtils import readCSV, timeFromString, timeSortAndSubset
-import IMOSnetCDF as inc
+from datetime import datetime
 
+import numpy as np
+
+import IMOSnetCDF as inc
+from dataUtils import readCSV, timeFromString, timeSortAndSubset
 
 ### module variables ###################################################
 

--- a/ANMN/AM/test_dest_path.py
+++ b/ANMN/AM/test_dest_path.py
@@ -24,6 +24,7 @@ Test cases:
 import os
 import unittest
 from tempfile import mkdtemp
+
 from dest_path import ANMNAMFileClassifier, FileClassifierException
 from test_file_classifier import make_test_file
 

--- a/ANMN/NRSMAI_product/NRSMAI_product_from_matfile.py
+++ b/ANMN/NRSMAI_product/NRSMAI_product_from_matfile.py
@@ -4,15 +4,16 @@
 # Ridgway's scripts and write them to IMOS netCDF files.
 
 
+import argparse
 import os
 import sys
-import argparse
+from datetime import datetime, timedelta
+
 import numpy as np
 from numpy.ma import MaskedArray
 from scipy.io import loadmat
-from datetime import datetime, timedelta
-import IMOSnetCDF as inc
 
+import IMOSnetCDF as inc
 
 ### Hard-coded values
 

--- a/ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py
+++ b/ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py
@@ -26,20 +26,23 @@ have to be contacted to sort out issues.
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-from dest_path import *
-from netCDF4 import num2date, date2num, Dataset
-from tendo import singleton
-from time import strftime
 import logging
+import os
 import re
-import sys, os
 import shutil
+import sys
 import time
 import unittest as data_validation_test
+from time import strftime
+
+from netCDF4 import Dataset, date2num, num2date
+from tendo import singleton
+
+from aims.realtime_util import *
+from dest_path import *
 
 # generic aims functions to access aims web service
 sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from aims.realtime_util import *
 
 def modify_anmn_nrs_netcdf(netcdf_file_path, channel_id_info):
     """ Modify the downloaded netCDF file so it passes both CF and IMOS checker

--- a/ANMN/NRS_AIMS/REALTIME/dest_path.py
+++ b/ANMN/NRS_AIMS/REALTIME/dest_path.py
@@ -5,9 +5,12 @@ Returns the relative path of a ANMN NRS NetCDF file
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-import os, sys
-from netCDF4 import Dataset
+import os
 import re
+import sys
+
+from netCDF4 import Dataset
+
 
 def get_main_anmn_nrs_var(netcdf_file_path):
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')

--- a/ANMN/NRSrealtime/destPath.py
+++ b/ANMN/NRSrealtime/destPath.py
@@ -5,8 +5,9 @@
 
 
 import os
-import sys
 import re
+import sys
+
 from netCDF4 import Dataset
 
 

--- a/ANMN/QLD/destPath.py
+++ b/ANMN/QLD/destPath.py
@@ -5,8 +5,9 @@
 
 
 import os
-import sys
 import re
+import sys
+
 from netCDF4 import Dataset
 
 

--- a/ANMN/acoustic/PAmat2netCDF.py
+++ b/ANMN/acoustic/PAmat2netCDF.py
@@ -4,9 +4,10 @@
 # IMOS netCDF file.
 
 from optparse import OptionParser
-from scipy.io import loadmat
-from IMOSnetCDF import IMOSnetCDFFile
 
+from scipy.io import loadmat
+
+from IMOSnetCDF import IMOSnetCDFFile
 
 # get file from command line
 parser = OptionParser()

--- a/ANMN/acoustic/compare_matfiles.py
+++ b/ANMN/acoustic/compare_matfiles.py
@@ -1,8 +1,8 @@
-from scipy.io import loadmat
-from datetime import datetime, timedelta
-from datetime import date
-import numpy as np
 import os
+from datetime import date, datetime, timedelta
+
+import numpy as np
+from scipy.io import loadmat
 
 #filepath  = '/seagate/archive/PAPCA/2823_leftovers__'
 filepath  = './'
@@ -91,4 +91,3 @@ if False:
             files.append(f[0][0])
     for f in files:
         os.system( "sed '2p;d' /seagate/public/PAPCA/2823/20090719/raw/%s.DAT" % f )
-

--- a/ANMN/acoustic/makeSpectrogram.py
+++ b/ANMN/acoustic/makeSpectrogram.py
@@ -3,14 +3,16 @@
 # Read in a Matlab file containing a spectrogram and convert it to a
 # series of .png bitmaps of a given size
 
-import sys, os
-import numpy as np
-from scipy.io import loadmat
-from matplotlib.pyplot import imsave
+import argparse
+import os
+import sys
 from datetime import datetime, timedelta
+
+import numpy as np
+from matplotlib.pyplot import imsave
 from psycopg2 import connect
 from psycopg2.tz import FixedOffsetTimezone
-import argparse
+from scipy.io import loadmat
 
 
 def moveFiles(fromDir, toDir, fileNames, nameEnd='', moveCmd='mv -nv'):

--- a/ANMN/acoustic/readMetadata.py
+++ b/ANMN/acoustic/readMetadata.py
@@ -2,7 +2,8 @@
 #
 # Read metadata and convert to csv
 
-import re, sys
+import re
+import sys
 
 
 # convert Rob's "Set details" field into site code, deployment name, logger id, frequency and position
@@ -141,5 +142,3 @@ for rowDict in allRows:
                 values.append("'" + value + "'")
 
     print ','.join(values)
-
-

--- a/ANMN/acoustic/sortRecordings.py
+++ b/ANMN/acoustic/sortRecordings.py
@@ -3,10 +3,12 @@
 # Group raw acoustic recording files by UT day and zip into
 # daiyl archives.
 
-import sys, os
-from datetime import datetime, timedelta
-from acoustic.acousticUtils import recordingStartTime
 import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+from acoustic.acousticUtils import recordingStartTime
 
 
 def makeZip(zipfile, fileList):

--- a/ANMN/burst_averaged_product/burst_average.py
+++ b/ANMN/burst_averaged_product/burst_average.py
@@ -4,21 +4,23 @@
 Burst Average Product creation from WQM and CTD FV01 files
 ./burst_average_product.py input_netcdf.nc /output_dir
 """
-from datetime import datetime
-from file_classifier import MooringFileClassifier
-from generate_netcdf_att import generate_netcdf_att
-from math import isnan
-from netCDF4 import Dataset, num2date, date2num
-from util import get_git_revision_script_url
 import argparse
-import numpy as np
 import os
-import pandas as pd
 import re
 import shutil
 import sys
 import tempfile
 import time
+from datetime import datetime
+from math import isnan
+
+import numpy as np
+import pandas as pd
+from netCDF4 import Dataset, date2num, num2date
+
+from file_classifier import MooringFileClassifier
+from generate_netcdf_att import generate_netcdf_att
+from util import get_git_revision_script_url
 
 
 def get_input_file_rel_path(input_netcdf_file_path):

--- a/ANMN/common/dest_path.py
+++ b/ANMN/common/dest_path.py
@@ -16,9 +16,10 @@ Assume: (will be checked by handler)
  * Site code has been validated in checker (if exists)
 """
 
-import sys
 import os
-from file_classifier import MooringFileClassifier, FileClassifierException
+import sys
+
+from file_classifier import FileClassifierException, MooringFileClassifier
 
 
 class NonNetCDFFileClassifier(MooringFileClassifier):

--- a/ANMN/common/previous_versions.py
+++ b/ANMN/common/previous_versions.py
@@ -4,13 +4,15 @@
 # the destination path.
 
 
-import os
-import sys
-import re
-from glob import glob
-from netCDF4 import Dataset
-from datetime import datetime
 import argparse
+import os
+import re
+import sys
+from datetime import datetime
+from glob import glob
+
+from netCDF4 import Dataset
+
 from file_classifier import MooringFileClassifier
 
 

--- a/ANMN/common/test_dest_path.py
+++ b/ANMN/common/test_dest_path.py
@@ -3,7 +3,8 @@
 
 import os
 import unittest
-from dest_path import NonNetCDFFileClassifier, FileClassifierException
+
+from dest_path import FileClassifierException, NonNetCDFFileClassifier
 
 
 class TestNonNetCDFFileClassifier(unittest.TestCase):

--- a/ANMN/common/test_previous_versions.py
+++ b/ANMN/common/test_previous_versions.py
@@ -19,14 +19,15 @@ Test cases:
 * new file has same creation date as prev file (probably same file)
 """
 
-import unittest
 import os
+import shutil
 import sys
+import unittest
 from StringIO import StringIO
 from tempfile import mkdtemp
-import shutil
-from test_file_classifier import make_test_file
+
 from previous_versions import FileMatcher, FileMatcherException
+from test_file_classifier import make_test_file
 
 
 class TestFileMatcher(unittest.TestCase):

--- a/ANMN/temperature_grid_product/anmn_temp_gridded_product.py
+++ b/ANMN/temperature_grid_product/anmn_temp_gridded_product.py
@@ -20,24 +20,25 @@ Author: laurent.besnard@utas.edu.au
 """
 
 
-from datetime import datetime, timedelta
-from generate_netcdf_att import generate_netcdf_att, get_imos_parameter_info
-from imos_logging import IMOSLogging
-from matplotlib import gridspec
-from netCDF4 import Dataset, num2date, date2num
-from util import get_git_revision_script_url
-from util import wfs_request_matching_file_pattern
 import argparse
 import bisect
-import numpy as np
 import os
-import pandas as pd
-import pylab as pl
 import re
-import sys
 import shutil
+import sys
 import tempfile
 import urllib2
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import pylab as pl
+from matplotlib import gridspec
+from netCDF4 import Dataset, date2num, num2date
+
+from generate_netcdf_att import generate_netcdf_att, get_imos_parameter_info
+from imos_logging import IMOSLogging
+from util import get_git_revision_script_url, wfs_request_matching_file_pattern
 
 
 def plot_abs_comparaison_old_new_product(old_product_rel_path, new_nc_path):

--- a/AUV/auv_viewer_processing/auv_processing.py
+++ b/AUV/auv_viewer_processing/auv_processing.py
@@ -5,23 +5,25 @@ TODO
 -improve reporting function
 """
 
-from datetime import datetime, timedelta
-from functools import partial
-from geopy.distance import vincenty
-from imos_logging import IMOSLogging
-from multiprocessing import Pool, cpu_count
-from netCDF4 import Dataset, num2date
-from osgeo import osr, gdal
-import StringIO
 import argparse
 import csv
 import operator
 import os
 import re
 import shutil
+import StringIO
 import subprocess
 import urllib2
 import uuid
+from datetime import datetime, timedelta
+from functools import partial
+from multiprocessing import Pool, cpu_count
+
+from geopy.distance import vincenty
+from netCDF4 import Dataset, num2date
+
+from imos_logging import IMOSLogging
+from osgeo import gdal, osr
 
 AUV_WIP_DIR = os.path.join(os.environ.get('WIP_DIR'), 'AUV', 'AUV_VIEWER_PROCESSING')
 

--- a/CSIRO/CARS/dest_path.py
+++ b/CSIRO/CARS/dest_path.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 
-
 if __name__ == '__main__':
     # read filename from command line
     if len(sys.argv) < 2:

--- a/FAIMMS/REALTIME/dest_path.py
+++ b/FAIMMS/REALTIME/dest_path.py
@@ -6,9 +6,12 @@ author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
 import datetime
-import os, sys
-from netCDF4 import Dataset, num2date
+import os
 import re
+import sys
+
+from netCDF4 import Dataset, num2date
+
 
 def get_main_faimms_var(netcdf_file_path):
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')

--- a/FAIMMS/REALTIME/faimms.py
+++ b/FAIMMS/REALTIME/faimms.py
@@ -27,10 +27,6 @@ author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
 
-from dest_path import *
-from netCDF4 import num2date, date2num, Dataset
-from tendo import singleton
-from time import strftime
 import logging
 import os
 import re
@@ -38,9 +34,16 @@ import shutil
 import sys
 import time
 import unittest as data_validation_test
+from time import strftime
+
+from netCDF4 import Dataset, date2num, num2date
+from tendo import singleton
+
+from aims.realtime_util import *
+from dest_path import *
+
 # generic aims functions to access aims web service
 sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from aims.realtime_util import *
 
 
 def modify_faimms_netcdf(netcdf_file_path, channel_id_info):

--- a/SOOP/SOOP_ASF_SST_XBT/SOOP_BOM_ASF_SST.py
+++ b/SOOP/SOOP_ASF_SST_XBT/SOOP_BOM_ASF_SST.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
+import argparse
+import fnmatch
 import os
 import re
-import sys
 import shutil
+
 from tendo import singleton
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.lftp_sync import LFTPSync
-from python.imos_logging import IMOSLogging
-import fnmatch
-import argparse
+
+from imos_logging import IMOSLogging
+from lftp_sync import LFTPSync
+
 
 def download_lftp_dat_files():
     """

--- a/SOOP/SOOP_ASF_SST_XBT/SOOP_XBT_NRT.py
+++ b/SOOP/SOOP_ASF_SST_XBT/SOOP_XBT_NRT.py
@@ -1,17 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-import sys
-from tempfile import mkstemp
-import shutil
-from tendo import singleton
-import argparse
 
-from subroutines.soop_xbt_realtime_processSBD import soop_xbt_realtime_processSBD
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.imos_logging import IMOSLogging
-from python.lftp_sync import LFTPSync
-from python.util import list_files_recursively
+import argparse
+import os
+import shutil
+from tempfile import mkstemp
+
+from tendo import singleton
+
+from imos_logging import IMOSLogging
+from lftp_sync import LFTPSync
+from subroutines.soop_xbt_realtime_processSBD import \
+    soop_xbt_realtime_processSBD
+from util import list_files_recursively
+
 
 def main(force_reprocess_all=False):
     # will sys.exit(-1) if other instance is running

--- a/SOOP/SOOP_ASF_SST_XBT/soop_asf_sst_pipeline/convert_netcdf_time_to_imos.py
+++ b/SOOP/SOOP_ASF_SST_XBT/soop_asf_sst_pipeline/convert_netcdf_time_to_imos.py
@@ -1,9 +1,10 @@
 #/usr/bin/env python
 
-import sys, getopt
+import getopt
+import sys
 
-from netCDF4 import Dataset
-from netCDF4 import num2date, date2num
+from netCDF4 import Dataset, date2num, num2date
+
 
 def convertTimeCftoImos(netcdfFilePath):
     """

--- a/SOOP/SOOP_ASF_SST_XBT/soop_asf_sst_pipeline/dest_path.py
+++ b/SOOP/SOOP_ASF_SST_XBT/soop_asf_sst_pipeline/dest_path.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+
 import ntpath
 import os
 import sys
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.ship_callsign import ship_callsign_list
+
+from ship_callsign import ship_callsign_list
+
 
 class SoopBomAsfSstDestPath:
 

--- a/SOOP/SOOP_ASF_SST_XBT/soop_xbt_pipeline/create_plot.py
+++ b/SOOP/SOOP_ASF_SST_XBT/soop_xbt_pipeline/create_plot.py
@@ -5,32 +5,19 @@
 # Institute: IMOS / eMII
 # email address: laurent.besnard@utas.edu.au
 
-import sys, os
-import tempfile
-import shutil
-
-# the next 3 lines are needed to create plots without a xserver
-MPLCONFIGDIR = tempfile.mkdtemp()
-os.environ['MPLCONFIGDIR'] = MPLCONFIGDIR
-import matplotlib
-matplotlib.use('Agg') # because no Xserver. has to be run after import before pylab
-
-import string
 import datetime
-import re
-from numpy import ma
-from netCDF4 import Dataset, num2date
-from matplotlib.pyplot import (figure, plot, xlabel, ylabel, title, show, xticks)
-import matplotlib.pyplot as plt
-import pylab
 import itertools
+import sys
+import tempfile
 
-def exit_cleanup(retval):
-    shutil.rmtree(MPLCONFIGDIR)
-    exit(retval)
+from matplotlib.pyplot import (plot, savefig, subplots, subplots_adjust, text,
+                               title, xticks)
+from netCDF4 import Dataset, num2date
+from numpy import ma
+
 
 def create_plot(netcdfFilePath):
-
+    """ create plot to be ingested in SOOP XBT NRT pipeline"""
     F                     = Dataset(netcdfFilePath, 'r', format='NETCDF4')
     cruise_id             = F.XBT_cruise_ID
     sea_water_temperature = F.variables['TEMP']
@@ -57,21 +44,19 @@ def create_plot(netcdfFilePath):
     temp_values  = ma.masked_values(temp_values, F.variables['TEMP']._FillValue)
     depth_values = ma.masked_values(depth_values, F.variables['DEPTH']._FillValue)
 
-    fig, ax1 = plt.subplots(figsize=(13,9.2), dpi=80, facecolor='w', edgecolor='k')
-    fig.canvas.set_window_title('A Boxplot Example')
-    plt.subplots_adjust(left=0.075, right=0.95, top=0.9, bottom=0.25)
+    fig, ax1 = subplots(figsize=(13, 9.2), dpi=80, facecolor='w', edgecolor='k')
+    subplots_adjust(left=0.075, right=0.95, top=0.9, bottom=0.25)
 
     ax1.set_xlabel(sea_water_temperature.long_name + ' in ' + sea_water_temperature.units)
     ax1.set_ylabel(depth.long_name + ' in ' + depth.units)
 
     try:
         if all(temp_values.mask):
-            plt.text(0.5, 0.5, 'No Good Data available', color='r',
-                fontsize=20,
-                horizontalalignment='center',
-                verticalalignment='center',
-                transform=ax1.transAxes,
-            )
+            text(0.5, 0.5, 'No Good Data available', color='r',
+                 fontsize=20,
+                 horizontalalignment='center',
+                 verticalalignment='center',
+                 transform=ax1.transAxes)
         else:
             plot(temp_values[:], -depth_values[:])
     except:
@@ -81,23 +66,26 @@ def create_plot(netcdfFilePath):
     xticks([-3, 0, 5, 10, 15, 20, 25, 30, 35])
 
     date_start = datetime.datetime.strptime(F.time_coverage_start, "%Y-%m-%dT%H:%M:%SZ").strftime("%Y-%m-%d %H:%M:%S UTC")
-    title(F.title + '\n Cruise  ' + cruise_id + '-' + F.XBT_line_description + ' - XBT id ' + str(xbt_unique_id) + '\nlocation ' + "%0.2f" % lat + ' S ; ' + "%0.2f" % lon + ' E\n' + date_start, fontsize=10)
+    title(F.title + '\n Cruise  ' + cruise_id + '-' + F.XBT_line_description +
+          ' - XBT id ' + str(xbt_unique_id) + '\nlocation ' + "%0.2f" % lat +
+          ' S ; ' + "%0.2f" % lon + ' E\n' + date_start, fontsize=10)
 
     F.close()
     jpg_output = tempfile.NamedTemporaryFile(delete=False)
-    matplotlib.pyplot.savefig(jpg_output)
+    savefig(jpg_output)
     return jpg_output.name
 
-if __name__== '__main__':
+
+if __name__ == '__main__':
     # Read filename from command line
     if len(sys.argv) < 2:
         print >>sys.stderr, 'No filename specified!'
-        exit_cleanup(1)
+        exit(1)
 
     jpg_output = create_plot(sys.argv[1])
 
     if not jpg_output:
-        exit_cleanup(1)
+        exit(1)
 
     print jpg_output
-    exit_cleanup(0)
+    exit(0)

--- a/SOOP/SOOP_ASF_SST_XBT/soop_xbt_pipeline/dest_path.py
+++ b/SOOP/SOOP_ASF_SST_XBT/soop_xbt_pipeline/dest_path.py
@@ -4,7 +4,9 @@
 # author Laurent Besnard, laurent.besnard@utas.edu.au
 
 import datetime
-import os, sys
+import os
+import sys
+
 from netCDF4 import Dataset
 
 

--- a/SOOP/SOOP_ASF_SST_XBT/soop_xbt_pipeline/return_soop_xbt_good_depth_dimension.py
+++ b/SOOP/SOOP_ASF_SST_XBT/soop_xbt_pipeline/return_soop_xbt_good_depth_dimension.py
@@ -5,8 +5,9 @@ the value of the dimension where this happens. If not, the original lenght of th
 returned
 """
 
-from netCDF4 import Dataset
 import sys
+
+from netCDF4 import Dataset
 
 if __name__ == '__main__':
     # read filename from command line

--- a/SOOP/SOOP_ASF_SST_XBT/subroutines/soop_xbt_realtime_processSBD.py
+++ b/SOOP/SOOP_ASF_SST_XBT/subroutines/soop_xbt_realtime_processSBD.py
@@ -5,15 +5,16 @@ Process SBD binary files
 Please read ../doc/Devil ...pdf to understand how the files are written
 """
 
-import os
-import time
-import sys
-import logging
-logger = logging.getLogger(__name__)
 import datetime
+import logging
+import os
+import sys
+import time
 
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.ship_callsign import ship_callsign_list
+from ship_callsign import ship_callsign_list
+
+logger = logging.getLogger(__name__)
+
 
 class soop_xbt_realtime_processSBD:
 

--- a/SOOP/SOOP_BA/helper.py
+++ b/SOOP/SOOP_BA/helper.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os, sys
+
+import os
+import sys
+
 from netCDF4 import Dataset
 
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.ship_callsign import ship_callsign_list
+from ship_callsign import ship_callsign_list
 
 
 def ships():

--- a/SOOP/SOOP_CO2/dest_path.py
+++ b/SOOP/SOOP_CO2/dest_path.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os, sys
+
+import os
+import sys
+
 from netCDF4 import Dataset
 
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.ship_callsign import ship_callsign_list
+from ship_callsign import ship_callsign_list
 
 
 def ships():

--- a/SOOP/SOOP_TMV/create_plot.py
+++ b/SOOP/SOOP_TMV/create_plot.py
@@ -4,47 +4,36 @@
 # Script that generates timeseries plot of data along transect between Devonport and Port Melbourne\
 # 2 plots are generated :  (1) Time vs Temperature & Salinity (2) Time vs Chlorophyll & Turbidity
 
-import sys, os
-import tempfile
-import shutil
-
-# the next 3 lines are needed to create plots without a xserver
-MPLCONFIGDIR = tempfile.mkdtemp()
-os.environ['MPLCONFIGDIR'] = MPLCONFIGDIR
-import matplotlib
-matplotlib.use('Agg') # because no Xserver. has to be run after import before pylab
-
-import string
 import datetime
+import os
 import re
-import numpy as np
-from numpy import ma
-from netCDF4 import Dataset, num2date
-from matplotlib.pyplot import (figure, plot, xlabel, ylabel, title, show, xticks)
-import matplotlib.pyplot as plt
-import pylab
-from math import radians, cos, sin, asin, sqrt
-import pyproj
-import time
+import sys
+from math import sqrt
 
-def exit_cleanup(retval):
-    shutil.rmtree(MPLCONFIGDIR)
-    exit(retval)
+import numpy as np
+import pyproj
+from matplotlib.pyplot import savefig, subplots, subplots_adjust, text, title
+from netCDF4 import Dataset, num2date
+from numpy import ma
+
 
 def axis_positions():
     return [
-        [ 0,    -0.08, 'Melbourne'       ],
-        [ 0.18, -0.08, 'Port Philip Bay' ],
-        [ 0.55, -0.08, 'Bass Strait'     ],
-        [ 1,    -0.08, 'Devonport'       ],
+        [0,    -0.08, 'Melbourne'       ],
+        [0.18, -0.08, 'Port Philip Bay' ],
+        [0.55, -0.08, 'Bass Strait'     ],
+        [1,    -0.08, 'Devonport'       ],
     ]
 
-# get all the element forming a netcdf file name
+
 def get_file_parts(nc_file):
+    """ get all the element forming a netcdf file name"""
     return os.path.basename(nc_file).split("_")
+
 
 def is_iteratable(value):
     return hasattr(value, '__iter__')
+
 
 def add_png_extension(nc_file):
     name = os.path.basename(nc_file).split(".")[0]
@@ -52,25 +41,28 @@ def add_png_extension(nc_file):
     name = '%s%s' % (name, ext)
     return name
 
+
 def get_var_info():
     """
     Define variable information
     """
     return {
-        'TEMP' : [ 'Sea Surface Temperature', 'Degrees Celsius', 'temperature' ],
-        'PSAL' : [ 'Seawater Salinity',       '1e-3',            'salinity'    ],
-        'TURB' : [ 'Turbidity',               'NTU',             'turbidity'   ],
-        'CPHL' : [ 'Chlorophyll',             'ug l-1',          'chlorophyll' ],
+        'TEMP': [ 'Sea Surface Temperature', 'Degrees Celsius', 'temperature' ],
+        'PSAL': [ 'Seawater Salinity',       '1e-3',            'salinity'    ],
+        'TURB': [ 'Turbidity',               'NTU',             'turbidity'   ],
+        'CPHL': [ 'Chlorophyll',             'ug l-1',          'chlorophyll' ],
     }
+
 
 def get_transect():
     """
     Define full transect name
     """
     return {
-            'D2M' : 'Devonport - Melbourne',
-            'M2D' : 'Melbourne - Devonport'
+        'D2M': 'Devonport - Melbourne',
+        'M2D': 'Melbourne - Devonport'
     }
+
 
 def set_yaxis_properties(param, values):
     """
@@ -82,7 +74,7 @@ def set_yaxis_properties(param, values):
         tick_spacing = 1
 
     elif param == 'PSAL':
-    # range  somewhat arbitrary even if values can go outside the range
+        # range  somewhat arbitrary even if values can go outside the range
         if ma.max(values) < 36.8:
             miny = 33
             maxy = 37
@@ -96,35 +88,37 @@ def set_yaxis_properties(param, values):
         maxy = 1.6
         tick_spacing = .4
 
-    else: # param =='TURB'
+    else:
+        # param =='TURB'
         miny = 0
         maxy = 8
         tick_spacing = 2
 
     return miny, maxy, tick_spacing
 
-def compute_distance(lon, lat, transect):
 
+def compute_distance(lon, lat, transect):
     port_mel_lon = 144.93
     port_mel_lat = -37.85
     devonport_jetty_lon = 146.36388889
     devonport_jetty_lat = -41.177777
     p = pyproj.Proj(proj='utm', zone=55, ellps='WGS84')
 
-    dist = 0 ; j = 0
+    dist = 0
+    j = 0
     distance = ([])
     for i in range(len(lon)):
         if j == 0 and transect == 'D2M':
-            x1,y1 = p(devonport_jetty_lon, devonport_jetty_lat)
+            x1, y1 = p(devonport_jetty_lon, devonport_jetty_lat)
             j += 1
         elif j == 0 and transect == 'M2D':
-            x1,y1 = p(port_mel_lon, port_mel_lat)
+            x1, y1 = p(port_mel_lon, port_mel_lat)
             j += 1
         else:
-            x1,y1 = p(lon[i-1], lat[i-1])
+            x1, y1 = p(lon[i - 1], lat[i - 1])
 
-        x2,y2 = p(lon[i], lat[i])
-        dist += sqrt((x2 - x1)** 2 +(y2 -y1)** 2)/1000
+        x2, y2 = p(lon[i], lat[i])
+        dist += sqrt((x2 - x1)** 2 + (y2 - y1)** 2) / 1000
         distance.append(dist)
 
     if transect == 'D2M':
@@ -149,8 +143,8 @@ def create_plot_transect(netcdf_file_path, tmp_dir, param1, param2, transect):
     p1 = netcdf_file_obj.variables[param1]
     p2 = netcdf_file_obj.variables[param2]
     # mask data where lat or lon sert to fillvalue
-    
-    # plot only data with QC flag =1 ,2 (good data, probably good data)
+
+    # plot only data with QC flag =1, 2 (good data, probably good data)
     no_qc = 0
     good_flag = [1, 2]
 
@@ -173,8 +167,8 @@ def create_plot_transect(netcdf_file_path, tmp_dir, param1, param2, transect):
     # compute distance from Port Melbourne using great circle method
     distance = compute_distance(lon, lat, transect)
 
-    fig, ax1 = plt.subplots(figsize=(13,9.2), dpi=80, facecolor='w', edgecolor='k')
-    plt.subplots_adjust(left=0.075, right=0.95, top=0.9, bottom=0.25)
+    fig, ax1 = subplots(figsize=(13, 9.2), dpi=80, facecolor='w', edgecolor='k')
+    subplots_adjust(left=0.075, right=0.95, top=0.9, bottom=0.25)
 
     # set proprties for the first axe
     ax1.set_xlabel('Distance in km')
@@ -196,31 +190,28 @@ def create_plot_transect(netcdf_file_path, tmp_dir, param1, param2, transect):
     ax2.set_ylabel(get_var_info()[param2][0] + ' (' + get_var_info()[param2][1] + ')', color='r')
     (miny2, maxy2, tick_spacing2) = set_yaxis_properties(param2, p2_values)
     ax2.set_ylim(miny2, maxy2)
-    ax2.set_yticks(np.arange(miny2, maxy2 +.1, tick_spacing2))
+    ax2.set_yticks(np.arange(miny2, maxy2 + .1, tick_spacing2))
     for tl in ax2.get_yticklabels():
         tl.set_color('r')
 
     if is_iteratable(p1_values.mask) and all(p1_values.mask):
-        plt.text(0.5, 0.5, 'No Good Data available', color='r',
-            fontsize=20,
-            horizontalalignment='center',
-            verticalalignment='center',
-            transform=ax1.transAxes,
-        )
+        text(0.5, 0.5, 'No Good Data available', color='r',
+             fontsize=20,
+             horizontalalignment='center',
+             verticalalignment='center',
+             transform=ax1.transAxes)
     else:
-        ax1.plot(distance,p1_values[:], 'b-')
-        ax2.plot(distance,p2_values[:], 'r-')
+        ax1.plot(distance, p1_values[:], 'b-')
+        ax2.plot(distance, p2_values[:], 'r-')
 
         for axis_position_tuple in axis_positions():
-            plt.text(
-                axis_position_tuple[0],
-                axis_position_tuple[1],
-                axis_position_tuple[2],
-                fontsize=15,
-                horizontalalignment='center',
-                verticalalignment='center',
-                transform=ax1.transAxes,
-            )
+            text(axis_position_tuple[0],
+                 axis_position_tuple[1],
+                 axis_position_tuple[2],
+                 fontsize=15,
+                 horizontalalignment='center',
+                 verticalalignment='center',
+                 transform=ax1.transAxes)
 
     date_start = datetime.datetime.strptime(netcdf_file_obj.time_coverage_start, "%Y-%m-%dT%H:%M:%SZ").strftime("%d-%b-%Y")
     full_title = "%s and %s during a transect %s on the %s" % (get_var_info()[param1][0], get_var_info()[param2][0], get_transect()[transect], date_start)
@@ -232,16 +223,17 @@ def create_plot_transect(netcdf_file_path, tmp_dir, param1, param2, transect):
     png_output = add_png_extension(png_output)
 
     png_output = os.path.join(tmp_dir, png_output)
-    matplotlib.pyplot.savefig(png_output)
+    savefig(png_output)
     netcdf_file_obj.close()
 
     return png_output
 
-if __name__== '__main__':
+
+if __name__ == '__main__':
     # read filename from command line
     if len(sys.argv) < 3:
         print >>sys.stderr, "Usage: %s NETCDF_FILE TEMPORARY_OUTPUT_DIR" % sys.argv[0]
-        exit_cleanup(1)
+        exit(1)
 
     nc_file = sys.argv[1]
     tmp_dir = sys.argv[2]
@@ -250,6 +242,6 @@ if __name__== '__main__':
     png_output_ct = create_plot_transect(nc_file, tmp_dir, 'CPHL', 'TURB', transect)
 
     if (not png_output_ts or not png_output_ct):
-        exit_cleanup(1)
+        exit(1)
 
-    exit_cleanup(0)
+    exit(0)

--- a/SOOP/SOOP_TMV/destPath.py
+++ b/SOOP/SOOP_TMV/destPath.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os,sys
 import ntpath
+import os
+import sys
+
 
 def destination_path(ncFile):
         """

--- a/SOOP/SOOP_TRV/dest_path.py
+++ b/SOOP/SOOP_TRV/dest_path.py
@@ -5,9 +5,11 @@
 # lat mod: 19/11/2015
 
 import datetime
-import os, sys
-from netCDF4 import Dataset
+import os
 import re
+import sys
+
+from netCDF4 import Dataset
 
 
 def get_main_soop_trv_var(netcdf_file_path):

--- a/SOOP/SOOP_TRV/soop_trv.py
+++ b/SOOP/SOOP_TRV/soop_trv.py
@@ -10,17 +10,20 @@ and IMOS compliant The files are stored in data_wip_path as defined by confix.tx
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-from dest_path import *
-from netCDF4 import Dataset
-from ship_callsign import ship_callsign
-from tendo import singleton
 import os
 import shutil
 import sys
 import unittest as data_validation_test
+
+from netCDF4 import Dataset
+from tendo import singleton
+
+from aims.realtime_util import *
+from dest_path import *
+from ship_callsign import ship_callsign
+
 # generic aims functions to access aims web service
 sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from aims.realtime_util import *
 
 
 def modify_soop_trv_netcdf(netcdf_file_path, channel_id_info):

--- a/SRS/LJCO/dest_path.py
+++ b/SRS/LJCO/dest_path.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 import re
+import sys
 
 
 def remove_creation_date_from_filename(netcdf_file_path):

--- a/SRS/SRS_ALT/dest_path.py
+++ b/SRS/SRS_ALT/dest_path.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+
 from netCDF4 import Dataset
 
 

--- a/SRS/SRS_OC_BODBAW/dest_path.py
+++ b/SRS/SRS_OC_BODBAW/dest_path.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import os
-import sys
 import re
+import sys
+
 
 def remove_creation_date_from_filename(netcdf_file_path):
     return re.sub('_C-.*.nc$', '.nc', netcdf_file_path)

--- a/SRS/SRS_OC_LJCO_AERONET/download_aeronet.py
+++ b/SRS/SRS_OC_LJCO_AERONET/download_aeronet.py
@@ -9,19 +9,20 @@ This script downloads a lev20 file (CSV) and unzip it in the IMOS public folder
 laurent.besnard@utas.edu.au
 """
 
-import sys
+import glob
 import os
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.imos_logging import IMOSLogging
-from BeautifulSoup import BeautifulSoup
-import urllib2
 import re
+import shutil
+import sys
+import urllib2
 import zipfile
+from StringIO import StringIO
 from tempfile import mkdtemp, mkstemp
 from urllib import urlopen
-from StringIO import StringIO
-import glob
-import shutil
+
+from BeautifulSoup import BeautifulSoup
+
+from imos_logging import IMOSLogging
 
 NASA_LEV2_URL = "http://aeronet.gsfc.nasa.gov/cgi-bin/print_warning_opera_v2_new?site=Lucinda&year=110&month=6&day=1&year2=110&month2=6&day2=30&LEV20=1&AVG=10"
 

--- a/SRS/SRS_OC_RADIOMETER/dest_path.py
+++ b/SRS/SRS_OC_RADIOMETER/dest_path.py
@@ -3,12 +3,15 @@
 #
 # author Laurent Besnard, laurent.besnard@utas.edu.au
 
-from netCDF4 import Dataset
 import datetime
-import os, sys
+import os
 import re
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.ship_callsign import ship_callsign_list
+import sys
+
+from netCDF4 import Dataset
+
+from ship_callsign import ship_callsign_list
+
 
 def remove_creation_date_from_filename(netcdf_filename):
     return re.sub('_C-.*$', '.nc', netcdf_filename)

--- a/bin/geonetwork_broken_link_checker.py
+++ b/bin/geonetwork_broken_link_checker.py
@@ -3,12 +3,14 @@
 import logging
 import os
 import re
-import requests
 import smtplib
 import xml.etree.ElementTree as ET
 
 import click
-from requests.packages.urllib3.exceptions import InsecureRequestWarning, InsecurePlatformWarning, SNIMissingWarning
+import requests
+from requests.packages.urllib3.exceptions import (InsecurePlatformWarning,
+                                                  InsecureRequestWarning,
+                                                  SNIMissingWarning)
 
 # Logging configuration
 logging.basicConfig(level=logging.INFO)

--- a/lib/aims/realtime_util.py
+++ b/lib/aims/realtime_util.py
@@ -12,23 +12,27 @@ data.aims.gov.au/gbroosdata/services/rss/netcdf/level0/300  -> NRS DARWIN YONGAL
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-from netCDF4 import num2date, date2num, Dataset
-from retrying import retry
-from time import gmtime, strftime
-from util import pass_netcdf_checker
-import dotenv
 import logging
-import numpy
-import os, sys
+import os
 import pickle
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
-import urllib2, urllib
+import urllib
+import urllib2
 import xml.etree.ElementTree as ET
 import zipfile
+from time import gmtime, strftime
+
+import dotenv
+import numpy
+from netCDF4 import Dataset, date2num, num2date
+from retrying import retry
+
+from util import pass_netcdf_checker
 
 
 #####################

--- a/lib/python/IMOSfilename.py
+++ b/lib/python/IMOSfilename.py
@@ -7,7 +7,6 @@
 import re
 from datetime import datetime
 
-
 #### DATA ###################################################################
 
 # List of valid facility/sub-facility codes.
@@ -244,4 +243,3 @@ def parseFilename(filename, minFields=6):
 
 
 ### Given the relevant information for a data set, create the correct filename
-

--- a/lib/python/IMOSnetCDF.py
+++ b/lib/python/IMOSnetCDF.py
@@ -3,17 +3,19 @@
 # Python module to manage IMOS-standard netCDF data files.
 
 
-from netCDF4 import Dataset
-import numpy as np
-from datetime import datetime, timedelta
-import os, re, time
-import sys
-from collections import OrderedDict
 import csv
+import os
+import re
+import sys
+import time
+from collections import OrderedDict
 from copy import deepcopy
-from tempfile import mkstemp
+from datetime import datetime, timedelta
 from shutil import move
+from tempfile import mkstemp
 
+import numpy as np
+from netCDF4 import Dataset
 
 #############################################################################
 

--- a/lib/python/dataUtils.py
+++ b/lib/python/dataUtils.py
@@ -3,20 +3,12 @@
 # Basic functions for common file- & data-manipulation tasks
 
 
-### reading data in csv files
-
 import csv
+from datetime import datetime
+
 import numpy as np
-from datetime import datetime, timedelta
 from netCDF4 import Dataset
 from scipy.io import loadmat
-
-# use Agg backend for so code can run in background
-import matplotlib
-if matplotlib.get_backend() <> 'Agg':
-    matplotlib.use('Agg')
-from matplotlib.pyplot import figure, close
-from matplotlib.ticker import ScalarFormatter
 
 
 def readCSVheader(filename):
@@ -51,11 +43,11 @@ def readCSV(filename, format):
     table = []
     for row in rd:
         table.append(tuple(row))
-           
+
     # convert this raw table into a numpy array
     try:
         arr = np.array(table, dtype=format)
-    except: 
+    except:
         print
         print "Couldn't convert data read from "+filename+" to given format!"
         print "Returning raw table instead."
@@ -89,13 +81,13 @@ def timeFromString(timeStr, epoch, format='%Y-%m-%dT%H:%M:%SZ'):
     """
     Convert time from a string to two arrays, returned as a tuple. The
     first gives the decimal days from the epoch (given as a datetime
-    obect). The second is an array of datetime objects. 
+    obect). The second is an array of datetime objects.
     The default input format (as defined for datetime.strptime) is
     '%Y-%m-%dT%H:%M:%SZ'.
     """
     dtime = []
     time  = []
-    for tstr in timeStr: 
+    for tstr in timeStr:
         dt = datetime.strptime(tstr, format)
         dtime.append(dt)
         time.append((dt-epoch).total_seconds())
@@ -143,7 +135,7 @@ def timeSubset(time, dtime, data, start_date=None, end_date=None):
         while i < j and dtime[i] < start_date:
             i += 1
     if end_date:
-        while i < j and dtime[j-1] > end_date: 
+        while i < j and dtime[j-1] > end_date:
             j -= 1
     data = data[i:j]
     time = time[i:j]
@@ -166,7 +158,6 @@ def timeSortAndSubset(time, dtime, data, start_date=None, end_date=None):
     # select time range
     return timeSubset(time, dtime, data, start_date, end_date)
 
-    
 
 ### looking at netCDF files
 
@@ -180,9 +171,9 @@ def ncListVar(ncFile, attList=['standard_name','long_name','units']):
     """
 
     # open file
-    if type(ncFile) == str: 
+    if type(ncFile) == str:
         F = Dataset(ncFile)
-    else: 
+    else:
         F = ncFile
 
     print 'variable_name,type,dimensions,'+','.join(attList)
@@ -199,42 +190,9 @@ def ncListVar(ncFile, attList=['standard_name','long_name','units']):
             except AttributeError:
                 row.append('')
                 continue
-            if type(value) == str: 
+            if type(value) == str:
                 row.append('"'+value+'"')
-            else: 
+            else:
                 row.append(str(value))
 
         print ','.join(row)
-
-
-
-### plotting
-
-def plotRecent(dtime, variable, filename='plot.png', plot_days=7, xlabel='Time', ylabel='', title=''):
-    """
-    Quick plot of the recent values of a variable.
-    Returns the number of data points plotted.
-    """ 
-
-    # select time range to plot
-    now = datetime.utcnow()
-    start = now - timedelta(plot_days)
-    ii = np.where(dtime > start)[0]
-    if len(ii) == 0: return 0
-
-    # create plot
-    fig = figure()
-    ax = fig.add_subplot(111)
-    ax.yaxis.set_major_formatter( ScalarFormatter(useOffset=False) )
-    ax.plot(dtime[ii], variable[ii])
-    ax.axis(xmin=start, xmax=now)
-
-    if xlabel: ax.set_xlabel(xlabel)
-    if ylabel: ax.set_ylabel(ylabel)
-    if title: ax.set_title(title)
-
-    # save to file and close figure
-    fig.savefig(filename)
-    close(fig)
-
-    return len(ii)

--- a/lib/python/file_classifier.py
+++ b/lib/python/file_classifier.py
@@ -22,8 +22,9 @@ Expected use:
 """
 
 import os
-import sys
 import re
+import sys
+
 from netCDF4 import Dataset
 
 

--- a/lib/python/generate_netcdf_att.py
+++ b/lib/python/generate_netcdf_att.py
@@ -40,10 +40,13 @@ author: Besnard, Laurent
 email : laurent.besnard@utas.edu.au
 """
 
-from ConfigParser import SafeConfigParser
-from IMOSnetCDF import attributesFromIMOSparametersFile
-import numpy as np
 import os
+from ConfigParser import SafeConfigParser
+
+import numpy as np
+
+from IMOSnetCDF import attributesFromIMOSparametersFile
+
 
 def get_imos_parameter_info(nc_varname, *var_attname):
     """

--- a/lib/python/imos_logging.py
+++ b/lib/python/imos_logging.py
@@ -4,11 +4,8 @@ Class to simplify and standardise within eMII the use of the logging library for
 Python
 
 Howto:
-in a new file
 
-import os, sys
-sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
-from python.imos_logging import IMOSLogging
+from imos_logging import IMOSLogging
 
 logging      = IMOSLogging()
 logger       = logging.logging_start('/tmp/log.log')
@@ -26,6 +23,7 @@ email : laurent.besnard@utas.edu.au
 
 import logging
 import os
+
 
 class IMOSLogging():
 

--- a/lib/python/lftp_sync.py
+++ b/lib/python/lftp_sync.py
@@ -33,9 +33,9 @@ email  : laurent.besnard@utas.edu.au
 
 import os
 import re
+import shutil
 import tempfile
 import time
-import shutil
 import urllib
 
 

--- a/lib/python/test_file_classifier.py
+++ b/lib/python/test_file_classifier.py
@@ -2,11 +2,14 @@
 "Unit tests for FileClassifier classes"
 
 import os
-import unittest
-from file_classifier import FileClassifier, MooringFileClassifier, FileClassifierException
-from tempfile import mkstemp, mkdtemp
-from netCDF4 import Dataset
 import shutil
+import unittest
+from tempfile import mkdtemp, mkstemp
+
+from netCDF4 import Dataset
+
+from file_classifier import (FileClassifier, FileClassifierException,
+                             MooringFileClassifier)
 
 
 ### Util function

--- a/lib/test/python/manual_test_wfs_query.py
+++ b/lib/test/python/manual_test_wfs_query.py
@@ -6,7 +6,9 @@ author : besnard, laurent
 """
 
 import unittest
+
 from util import wfs_request_matching_file_pattern
+
 
 class TestWfsRequest(unittest.TestCase):
 

--- a/lib/test/python/test_generate_netcdf_att.py
+++ b/lib/test/python/test_generate_netcdf_att.py
@@ -8,12 +8,14 @@ author : besnard, laurent
 
 import os
 import sys
-
-import unittest
 import textwrap
-from netCDF4 import Dataset
+import unittest
 from tempfile import mkstemp
+
+from netCDF4 import Dataset
+
 from generate_netcdf_att import *
+
 
 class TestGenerateNetCDFAtt(unittest.TestCase):
 

--- a/lib/test/python/test_imos_logging.py
+++ b/lib/test/python/test_imos_logging.py
@@ -8,10 +8,11 @@ author : besnard, laurent
 
 import os
 import sys
-
 import unittest
 from tempfile import mkstemp
+
 from imos_logging import IMOSLogging
+
 
 class TestImosLogging(unittest.TestCase):
 

--- a/lib/test/python/test_lftp_sync.py
+++ b/lib/test/python/test_lftp_sync.py
@@ -7,13 +7,14 @@ author : besnard, laurent
 """
 
 import os
-import sys
-
-import unittest
 import shutil
+import sys
 import textwrap
+import unittest
 from tempfile import mkdtemp, mkstemp
+
 from lftp_sync import LFTPSync
+
 
 class TestGenerateNetCDFAtt(unittest.TestCase):
 

--- a/lib/test/python/test_nc_checker_call.py
+++ b/lib/test/python/test_nc_checker_call.py
@@ -5,9 +5,11 @@ unittest for lib/python/util.py netcdf checker call function
 author : besnard, laurent
 """
 
-from util import pass_netcdf_checker
 import os
 import unittest
+
+from util import pass_netcdf_checker
+
 
 class TestPassChecker(unittest.TestCase):
 

--- a/lib/test/python/test_ship_callsign.py
+++ b/lib/test/python/test_ship_callsign.py
@@ -5,14 +5,15 @@ Unit tests for ship_callsign functions
 author: Besnard, Laurent
 """
 
-import unittest
 import os
 import sys
+import unittest
+
+from python.ship_callsign import ship_callsign
 
 LIB_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..'))
 sys.path.insert(0, LIB_DIR)
 
-from python.ship_callsign import ship_callsign
 
 class TestShipCallSign(unittest.TestCase):
 

--- a/plant-image/plant-image.py
+++ b/plant-image/plant-image.py
@@ -1,14 +1,16 @@
 #!/usr/bin/python
 
-import os, sys
-import numpy as np
-import tempfile
-import shutil
-from netCDF4 import Dataset
 import logging
+import os
+import shutil
+import sys
+import tempfile
 import warnings
-from PIL import Image
 from datetime import datetime, timedelta
+
+import numpy as np
+from netCDF4 import Dataset
+from PIL import Image
 from scipy import misc
 
 # wget https://imos-data.s3-ap-southeast-2.amazonaws.com/IMOS/SRS/SST/ghrsst/L3U/n19/2015/20151231145731-ABOM-L3U_GHRSST-SSTskin-AVHRR19_D-Des.nc


### PR DESCRIPTION
basically mod 
```python
sys.path.insert(0, os.path.join(os.environ.get('DATA_SERVICES_DIR'), 'lib'))
from python.ship_callsign import ship_callsign_list
```

to 
```python
from ship_callsign import ship_callsign_list
```

sort imports, remove unused ones ...

NOT TESTED YET