### PR TITLE
Update util.py to reflect additional parameter. Update verbose param …

### DIFF
--- a/lib/python/util.py
+++ b/lib/python/util.py
@@ -122,7 +122,7 @@ def pass_netcdf_checker(netcdf_file_path, tests=['cf:latest', 'imos:latest']):
 
     for test in tests:
         # creation of a tmp json file. Only way (with html) to create an output not displayed to stdin by default
-        return_value, errors = ComplianceChecker.run_checker(netcdf_file_path, [test], 'None', 'normal', tmp_json_checker_output[1], 'json')
+        return_value, errors = ComplianceChecker.run_checker(netcdf_file_path, [test], 1, 'normal', output_filename=tmp_json_checker_output[1], output_format='json')
         had_errors.append(errors)
         return_values.append(return_value)
 


### PR DESCRIPTION
…to integer as per method docstring. Use kwargs to avoid similar positional issues in future.

@lbesnard I'd update it like this, in line with: https://github.com/aodn/compliance-checker/blob/931ca30a6de69bbfa74814dba5bbe02ceeb213ae/compliance_checker/runner.py#L30. Making those keyword arguments should insure it against similar keyword additions. If they changed the positional args you're still out of luck, but hopefully that won't happen...

```python
@param  verbose         Verbosity of the output (0, 1, 2)
```

Also noticed that verbose was supposed to be an integer, but the condition was evaluating to True anyway since:
```python
In [1]: 'None' > 0
Out[1]: True
```
https://github.com/aodn/compliance-checker/blob/931ca30a6de69bbfa74814dba5bbe02ceeb213ae/compliance_checker/runner.py#L165