### PR TITLE
remove unnecessary variable pythonpath

### DIFF
--- a/SOOP/SOOP_CO2/incoming_handler.sh
+++ b/SOOP/SOOP_CO2/incoming_handler.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-export PYTHONPATH="$DATA_SERVICES_DIR/SOOP"
 export SCRIPTPATH="$DATA_SERVICES_DIR/SOOP/SOOP_CO2"
 
 declare -r BACKUP_RECIPIENT=benedicte.pasquer@utas.edu.au


### PR DESCRIPTION
as it is overwriting the environment variable.
one line, super quick, any taker @lbesnard @mhidas ?