### PR TITLE
disable notification to uploader when receiving NRT text files

### DIFF
--- a/SOOP/SOOP_CO2/incoming_handler.sh
+++ b/SOOP/SOOP_CO2/incoming_handler.sh
@@ -137,7 +137,7 @@ main() {
     elif has_extension $file "nc"; then
         handle_netcdf_file $file
     else
-        file_error_and_report_to_uploader $BACKUP_RECIPIENT "Unknown file extension "`basename $file`
+        file_error $BACKUP_RECIPIENT "Unknown file extension "`basename $file`
     fi
 }
 


### PR DESCRIPTION
Disable the error notification until pipeline is ready to process NRT files