### PR TITLE
Turn IMOS checks back on in ABOS_DA pipeline

### DIFF
--- a/watch.d/ABOS_DA.json
+++ b/watch.d/ABOS_DA.json
@@ -1,5 +1,5 @@
 {
   "path": [ "ABOS/DA" ],
   "execute": "ABOS/common/incoming_handler.sh",
-  "execute_params": "--sub-facility 'DA' --site '(EAC1|EAC2|EAC3|EAC4|EAC5|ITFOMB|ITFTIN|ITFTSL|ITFTNS|POLYNYA1|POLYNYA2|TOTTEN1|TOTTEN2|TOTTEN3)' --checks 'cf'"
+  "execute_params": "--sub-facility 'DA' --site '(EAC1|EAC2|EAC3|EAC4|EAC5|ITFOMB|ITFTIN|ITFTSL|ITFTNS|POLYNYA1|POLYNYA2|TOTTEN1|TOTTEN2|TOTTEN3)' --checks 'cf imos:1.4'"
 }


### PR DESCRIPTION
(revert a4fbd47e0b55ad9fad02f6b52b112795b1ae3ed9)