### PR TITLE
Bash date considers an input STRING is in the server local time by de…

### DIFF
--- a/lib/common/time.sh
+++ b/lib/common/time.sh
@@ -10,8 +10,8 @@
 # $1 - lhs timestamp (ISO8601)
 # $2 - rhs timestamp (ISO8601)
 timestamp_is_increasing() {
-    local lhs=`date -d "$1" "+%s"`; shift
-    local rhs=`date -d "$1" "+%s"`; shift
+    local lhs=`date --utc -d "$1" "+%s"`; shift
+    local rhs=`date --utc -d "$1" "+%s"`; shift
     [ $rhs -gt $lhs ]
 }
 export -f timestamp_is_increasing


### PR DESCRIPTION
…fault, so that if a date/time is provided during the hour when change time to/from daylight saving, such date is considered invalid. For example date -d "2017-10-01 02:00:10Z" "+%s" returns an error.