### PR TITLE
IMOS checker: fix version of netCDF4 library to 1.2.4

### DIFF
--- a/lib/cc_plugin_imos/requirements.txt
+++ b/lib/cc_plugin_imos/requirements.txt
@@ -1,1 +1,2 @@
 compliance-checker>=2.0.0
+netCDF4==1.2.4


### PR DESCRIPTION
This is the version we have running in RC & prod, and it will not be upgraded there. However, the Jenkins build would be default install the latest version, and anything above 1.2.9 breaks the unittests.