### PR TITLE
Added check_netcdf_print_error to lib/common/netcdf-check.shlib/commo…

### DIFF
--- a/ACORN/BASH/incoming_handler_common.sh
+++ b/ACORN/BASH/incoming_handler_common.sh
@@ -111,7 +111,8 @@ main() {
     [ -z "$ACORN_HOURLY_AVG_DIR" ] && file_error "missing ACORN_HOURLY_AVG_DIR variable"
 
     regex_filter $file || file_error "Did not pass ACORN regex filter"
-    check_netcdf $file || file_error "Not a valid NetCDF file"
+    local err_msg
+    err_msg=$(check_netcdf_print_error $file) || file_error "'$err_msg'"
 
     local file_type=`get_type $file`
     [ x"$file_type" = x ] && echo "Unknown file type" 1>&2 && return 1

--- a/lib/common/netcdf-check.sh
+++ b/lib/common/netcdf-check.sh
@@ -49,6 +49,17 @@ check_netcdf() {
 }
 export -f check_netcdf
 
+# checks a netcdf file and prints stderr if any
+# $1 - netcdf file to check
+check_netcdf_print_error() {
+    local file=$1; shift
+    local stderr=$(ncdump -h $file 2>&1 >/dev/null)
+    local exit_status=$?
+    [ $exit_status -ne 0 ] && echo "Failed netcdf format check with error: '$stderr'"
+    return $exit_status
+}
+export -f check_netcdf_print_error
+
 # add/update global attributes in a netCDF file to record the fact
 # that it has passed the checker.
 #   - compliance_checker_version (e.g. "2.2.0")


### PR DESCRIPTION
…n/netcdf-check.sh so that the error message from ncdump can be retrieved and logged. Updated ACORN/BASH/incoming_handler_common.sh to take advantage of this new function.