### PR TITLE
Pin awscli to be greater than or equal to current latest release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ scipy==0.14.1
 six
 tendo==0.2.8
 click
-awscli
+awscli>=1.16.99
 Fiona==1.7.1
 wand==0.4.4
 xlrd


### PR DESCRIPTION
Avoids back dependency issues with boto3/botocore dependencies elsewhere