### PR TITLE
Bump awscli to version compatible with boto3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ scipy==0.14.1
 six
 tendo==0.2.8
 click
-awscli>=1.16.99
+awscli>=1.16.128
 Fiona==1.7.1
 wand==0.4.4
 xlrd


### PR DESCRIPTION
Latest install of boto3 requires botocore>=1.12.128,<1.13.0.

Earliest release of awscli that doesn't violate this is 1.16.128 (installs botocore 1.12.128).  Previous release (1.16.127) wants to install botocore 1.12.117.

fixes https://github.com/aodn/issues/issues/415