### PR TITLE
requests-requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ pandas==0.18.1
 pyproj==1.9.4
 python-dateutil
 python-dotenv==0.5.1
-requests==2.12.1
+requests>=2.12.1,<2.20.0
 pyexcel==0.3.3
 pyexcel-xls==0.2.3
 retrying==1.3.3


### PR DESCRIPTION
There is no need to pin this exact version of requests, and it causes contention with botocore due to a shared urllib3 dependency. This should avoid the scenario where one package installs requests, and then subsequently  other package "upgrades" it to an incompatible version.