### PR TITLE
Read geoserver requests and load them as dicts

### DIFF
--- a/GeoserverCatalog/agg_utils.py
+++ b/GeoserverCatalog/agg_utils.py
@@ -1,0 +1,56 @@
+import csv
+from typing import Dict, List
+
+import requests
+
+MOORINGS_ADDRESS = "http://geoserver-123.aodn.org.au/geoserver/ows?typeName=moorings_all_map&SERVICE=WFS&REQUEST=GetFeature&VERSION=1.0.0&outputFormat=csv"
+CONTENT_SPLIT = '\r\n'
+KEY_SPLIT = ','
+REMOVE_KEYS = ''
+
+
+def get_geoserver_data(addr: str) -> str:
+    req = requests.get(addr)
+    content = req.content.decode('utf-8')
+    return content.splitlines()
+
+
+def process_geoserver_content(list_of_content: List[str]
+                              ) -> [List[str], List[str]]:
+    datalist = list(csv.reader(list_of_content, delimiter=KEY_SPLIT))
+    return datalist[0], datalist[1:]
+
+
+def geoserver_dict(keys: List[str], values: List[str],
+                   mkey: str = 'url') -> Dict[str, str]:
+    ind = keys.index(mkey)
+    res = {}
+    for items in values:
+        key = items[ind]
+        if key not in res.keys():
+            res[key] = {}
+        _extend_entry(res[key], keys, items, extend_type=list)
+    return res
+
+
+def _extend_entry(rdict: Dict[str, str],
+                  keys: List[str],
+                  items: List[str],
+                  extend_type=list):
+    """
+    Extend :rdict: :keys: for each item in :items: if there is more than one entry for the same key. The type used is :extend_type:.
+    """
+    if len(keys) != len(items):
+        raise ValueError("Length mismatch between keys and items arguments")
+
+    for sind, subfield in enumerate(keys):
+        if subfield in rdict.keys():
+            if isinstance(rdict[subfield], extend_type):
+                rdict[subfield] += [items[sind]]
+            else:
+                oldkey = rdict[subfield]
+                rdict[subfield] = extend_type()
+                rdict[subfield] += [oldkey]
+        else:
+            rdict[subfield] = items[sind]
+    pass

--- a/GeoserverCatalog/test_agg.py
+++ b/GeoserverCatalog/test_agg.py
@@ -1,0 +1,33 @@
+import pytest
+
+from agg_utils import (MOORINGS_ADDRESS, get_geoserver_data,
+                       process_geoserver_content, geoserver_dict)
+
+
+@pytest.mark.skip('slow')
+def test_get_geoserver_data():
+    content = get_geoserver_data(MOORINGS_ADDRESS)
+    assert len(content) > 0
+
+
+def test_process_geoserver():
+    content = get_geoserver_data(MOORINGS_ADDRESS)
+    keys, values = process_geoserver_content(content)
+    assert len(keys) > 0
+    assert len(values) > 0
+    assert keys not in values
+    assert len([True for value in values if value == keys]) == 0
+
+
+def test_dict_by_url():
+    content = get_geoserver_data(MOORINGS_ADDRESS)
+    keys, values = process_geoserver_content(content)
+    url_dict = geoserver_dict(keys, values, mkey='url')
+    assert len(url_dict) > 0
+
+
+def test_dict_by_sitecode():
+    content = get_geoserver_data(MOORINGS_ADDRESS)
+    keys, values = process_geoserver_content(content)
+    sitecode_dict = geoserver_dict(keys, values, mkey='site_code')
+    assert len(sitecode_dict) > 0


### PR DESCRIPTION
I just found out a playground code when I was doing GeoServer stuff.

I add some sugarcoating related to #934. Maybe you can re-use.

The code works to list URLs and even list URLs on the same site_code, or any field GeoServer throws out.