### PR TITLE
Python3 conversion

### DIFF
--- a/ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py
+++ b/ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Download ANMN NRS data from AIMS Web Service for Darwin, Yongala and Beagle
@@ -34,6 +34,7 @@ import shutil
 import traceback
 import unittest as data_validation_test
 
+from dest_path import get_anmn_nrs_site_name
 from netCDF4 import Dataset
 from tendo import singleton
 
@@ -47,8 +48,7 @@ from aims_realtime_util import (close_logger, convert_time_cf_to_imos,
                                 modify_aims_netcdf, parse_aims_xml,
                                 remove_dimension_from_netcdf,
                                 remove_end_date_from_filename, save_channel_info,
-                                set_up, rm_tmp_dir)
-from dest_path import get_anmn_nrs_site_name, get_main_anmn_nrs_var
+                                set_up, rm_tmp_dir, get_main_netcdf_var)
 from util import pass_netcdf_checker
 
 DATA_WIP_PATH = os.path.join(os.environ.get('WIP_DIR'), 'ANMN', 'NRS_AIMS_Darwin_Yongala_data_rss_download_temporary')
@@ -64,17 +64,17 @@ def modify_anmn_nrs_netcdf(netcdf_file_path, channel_id_info):
     """
     modify_aims_netcdf(netcdf_file_path, channel_id_info)
 
-    netcdf_file_obj                 = Dataset(netcdf_file_path, 'a', format='NETCDF4')
-    netcdf_file_obj.aims_channel_id =  int(channel_id_info['channel_id'])
+    netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')
+    netcdf_file_obj.aims_channel_id = int(channel_id_info['channel_id'])
 
     if 'Yongala' in channel_id_info['site_name']:
-        netcdf_file_obj.site_code     = 'NRSYON'
+        netcdf_file_obj.site_code = 'NRSYON'
         netcdf_file_obj.platform_code = 'Yongala NRS Buoy'
     elif 'Darwin' in channel_id_info['site_name']:
-        netcdf_file_obj.site_code     = 'NRSDAR'
+        netcdf_file_obj.site_code = 'NRSDAR'
         netcdf_file_obj.platform_code = 'Darwin NRS Buoy'
     elif 'Beagle' in channel_id_info['site_name']:
-        netcdf_file_obj.site_code     = 'DARBGF'
+        netcdf_file_obj.site_code = 'DARBGF'
         netcdf_file_obj.platform_code = 'Beagle Gulf Mooring'
     else:
         return False
@@ -84,29 +84,30 @@ def modify_anmn_nrs_netcdf(netcdf_file_path, channel_id_info):
 
     # some weather stations channels don't have a depth variable if sensor above water
     if 'depth' in netcdf_file_obj.variables.keys():
-        var                 = netcdf_file_obj.variables['depth']
-        var.long_name       = 'nominal depth'
-        var.positive        = 'down'
-        var.axis            = 'Z'
+        var = netcdf_file_obj.variables['depth']
+        var.long_name = 'nominal depth'
+        var.positive = 'down'
+        var.axis = 'Z'
         var.reference_datum = 'sea surface'
-        var.valid_min       = -10.0
-        var.valid_max       = 30.0
-        var.units           = 'm'  # some channels put degrees celcius instead ...
+        var.valid_min = -10.0
+        var.valid_max = 30.0
+        var.units = 'm'  # some channels put degrees celcius instead ...
         netcdf_file_obj.renameVariable('depth', 'NOMINAL_DEPTH')
 
     if 'DEPTH' in netcdf_file_obj.variables.keys():
-        var                 = netcdf_file_obj.variables['DEPTH']
-        var.coordinates     = "TIME LATITUDE LONGITUDE NOMINAL_DEPTH"
-        var.long_name       = 'actual depth'
+        var = netcdf_file_obj.variables['DEPTH']
+        var.coordinates = "TIME LATITUDE LONGITUDE NOMINAL_DEPTH"
+        var.long_name = 'actual depth'
         var.reference_datum = 'sea surface'
-        var.positive        = 'down'
-        var.valid_min       = -10.0
-        var.valid_max       = 30.0
-        var.units           = 'm'  # some channels put degrees celcius instead ...
+        var.positive = 'down'
+        var.valid_min = -10.0
+        var.valid_max = 30.0
+        var.units = 'm'  # some channels put degrees celcius instead ...
 
     netcdf_file_obj.close()
-    netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')  # need to close to save to file. as we call get_main_var just after
-    main_var        = get_main_anmn_nrs_var(netcdf_file_path)
+    netcdf_file_obj = Dataset(netcdf_file_path, 'a',
+                              format='NETCDF4')  # need to close to save to file. as we call get_main_var just after
+    main_var = get_main_netcdf_var(netcdf_file_path)
     # DEPTH, LATITUDE and LONGITUDE are not dimensions, so we make them into auxiliary cooordinate variables by adding this attribute
     if 'NOMINAL_DEPTH' in netcdf_file_obj.variables.keys():
         netcdf_file_obj.variables[main_var].coordinates = "TIME LATITUDE LONGITUDE NOMINAL_DEPTH"
@@ -124,9 +125,10 @@ def modify_anmn_nrs_netcdf(netcdf_file_path, channel_id_info):
 
 def move_to_tmp_incoming(netcdf_path):
     # [org_filename withouth creation date].[md5].nc to have unique filename in
-    new_filename = '%s.%s.nc' % (os.path.splitext(os.path.basename(remove_end_date_from_filename(netcdf_path)))[0], md5(netcdf_path))
+    new_filename = '%s.%s.nc' % (
+        os.path.splitext(os.path.basename(remove_end_date_from_filename(netcdf_path)))[0], md5(netcdf_path))
 
-    os.chmod(netcdf_path, 0664)  # change to 664 for pipeline v2
+    os.chmod(netcdf_path, 0o0664)  # change to 664 for pipeline v2
     shutil.move(netcdf_path, os.path.join(TMP_MANIFEST_DIR, new_filename))
 
 
@@ -150,10 +152,10 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
     if len(start_dates) != 0:
         # download monthly file
         for start_date, end_date in zip(start_dates, end_dates):
-            start_date           = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
-            end_date             = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_date = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            end_date = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
             netcdf_tmp_file_path = download_channel(channel_id, start_date, end_date, level_qc)
-            contact_aims_msg     = "Process of channel aborted - CONTACT AIMS"
+            contact_aims_msg = "Process of channel aborted - CONTACT AIMS"
 
             if netcdf_tmp_file_path is None:
                 logger.error('   Channel %s - not valid zip file - %s' % (str(channel_id), contact_aims_msg))
@@ -161,32 +163,38 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
 
             # NO_DATA_FOUND file only means there is no data for the selected time period. Could be some data afterwards
             if is_no_data_found(netcdf_tmp_file_path):
-                logger.warning('   Channel %s - No data for the time period:%s - %s' % (str(channel_id), start_date, end_date))
+                logger.warning(
+                    '   Channel %s - No data for the time period:%s - %s' % (str(channel_id), start_date, end_date))
                 shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
             else:
                 if is_time_var_empty(netcdf_tmp_file_path):
-                    logger.error('   Channel %s - No values in TIME variable - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error(
+                        '   Channel %s - No values in TIME variable - %s' % (str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
                 if not modify_anmn_nrs_netcdf(netcdf_tmp_file_path, channel_id_info):
-                    logger.error('   Channel %s - Could not modify the NetCDF file - Process of channel aborted' % str(channel_id))
+                    logger.error('   Channel %s - Could not modify the NetCDF file - Process of channel aborted' % str(
+                        channel_id))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
-                main_var = get_main_anmn_nrs_var(netcdf_tmp_file_path)
+                main_var = get_main_netcdf_var(netcdf_tmp_file_path)
                 if has_var_only_fill_value(netcdf_tmp_file_path, main_var):
-                    logger.error('   Channel %s - _Fillvalues only in main variable - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error(
+                        '   Channel %s - _Fillvalues only in main variable - %s' % (str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
                 if get_anmn_nrs_site_name(netcdf_tmp_file_path) == []:
-                    logger.error('   Channel %s - Unknown site_code gatt value - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error(
+                        '   Channel %s - Unknown site_code gatt value - %s' % (str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
                 if not is_time_monotonic(netcdf_tmp_file_path):
-                    logger.error('   Channel %s - TIME value is not strickly monotonic - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error('   Channel %s - TIME value is not strickly monotonic - %s' % (
+                        str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
@@ -194,9 +202,12 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
                 wip_path = os.environ.get('data_wip_path')
                 checker_retval = pass_netcdf_checker(netcdf_tmp_file_path, tests=['cf:latest', 'imos:1.3'])
                 if not checker_retval:
-                    logger.error('   Channel %s - File does not pass CF/IMOS compliance checker - Process of channel aborted' % str(channel_id))
+                    logger.error(
+                        '   Channel %s - File does not pass CF/IMOS compliance checker - Process of channel aborted' % str(
+                            channel_id))
                     shutil.copy(netcdf_tmp_file_path, os.path.join(wip_path, 'errors'))
-                    logger.error('   File copied to %s for debugging' % (os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
+                    logger.error('   File copied to %s for debugging' % (
+                        os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
@@ -204,9 +215,12 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
                 netcdf_tmp_file_path = fix_provider_code_from_filename(netcdf_tmp_file_path, 'IMOS_ANMN')
 
                 if re.search('IMOS_ANMN_[A-Z]{1}_', netcdf_tmp_file_path) is None:
-                    logger.error('   Channel %s - File name Data code does not pass REGEX - Process of channel aborted' % str(channel_id))
+                    logger.error(
+                        '   Channel %s - File name Data code does not pass REGEX - Process of channel aborted' % str(
+                            channel_id))
                     shutil.copy(netcdf_tmp_file_path, os.path.join(wip_path, 'errors'))
-                    logger.error('   File copied to %s for debugging' % (os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
+                    logger.error('   File copied to %s for debugging' % (
+                        os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
@@ -234,15 +248,17 @@ def process_qc_level(level_qc):
     xml_url = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level{level_qc}/300'.format(level_qc=level_qc)
     try:
         aims_xml_info = parse_aims_xml(xml_url)
-    except:
+    except Exception as err:
         logger.error('RSS feed not available')
         exit(1)
 
     for channel_id in aims_xml_info.keys():
         try:
             process_monthly_channel(channel_id, aims_xml_info, level_qc)
-        except Exception:
-            logger.error('   Channel %s QC%s - Failed, unknown reason - manual debug required' % (str(channel_id), str(level_qc)))
+        except Exception as err:
+            logger.error('   Channel {channel_id} QC{level_qc} - Failed, unknown reason - manual debug required'.
+                         format(channel_id=str(channel_id),
+                                level_qc=str(level_qc)))
             logger.error(traceback.print_exc())
 
 
@@ -253,31 +269,34 @@ class AimsDataValidationTest(data_validation_test.TestCase):
         This function checks that a downloaded file still has the same md5.
         """
         logging_aims()
-        channel_id                   = '84329'
-        from_date                    = '2016-01-01T00:00:00Z'
-        thru_date                    = '2016-01-02T00:00:00Z'
-        level_qc                     = 1
-        aims_rss_val                 = 300
-        xml_url                      = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/%s' % (str(level_qc), str(aims_rss_val))
+        channel_id = '84329'
+        from_date = '2016-01-01T00:00:00Z'
+        thru_date = '2016-01-02T00:00:00Z'
+        level_qc = 1
+        aims_rss_val = 300
+        xml_url = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/%s' % (
+            str(level_qc), str(aims_rss_val))
 
-        aims_xml_info                = parse_aims_xml(xml_url)
+        aims_xml_info = parse_aims_xml(xml_url)
         channel_id_info = aims_xml_info[channel_id]
-        self.netcdf_tmp_file_path    = download_channel(channel_id, from_date, thru_date, level_qc)
+        self.netcdf_tmp_file_path = download_channel(channel_id, from_date, thru_date, level_qc)
         modify_anmn_nrs_netcdf(self.netcdf_tmp_file_path, channel_id_info)
 
         # force values of attributes which change all the time
-        netcdf_file_obj              = Dataset(self.netcdf_tmp_file_path, 'a', format='NETCDF4')
+        netcdf_file_obj = Dataset(self.netcdf_tmp_file_path, 'a', format='NETCDF4')
         netcdf_file_obj.date_created = "1970-01-01T00:00:00Z"  # epoch
-        netcdf_file_obj.history      = 'data validation test only'
+        netcdf_file_obj.history = 'data validation test only'
         netcdf_file_obj.close()
 
     def tearDown(self):
-        shutil.copy(self.netcdf_tmp_file_path, os.path.join(os.environ['data_wip_path'], 'nc_unittest_%s.nc' % self.md5_netcdf_value))
+        shutil.copy(self.netcdf_tmp_file_path,
+                    os.path.join(os.environ['data_wip_path'],
+                                 'nc_unittest_{md5_val}.nc'.format(md5_val=self.md5_netcdf_value)))
         shutil.rmtree(os.path.dirname(self.netcdf_tmp_file_path))
 
     def test_aims_validation(self):
-        self.md5_expected_value = '2c354af05e56f3999fcfa3dda7bc8035'
-        self.md5_netcdf_value   = md5(self.netcdf_tmp_file_path)
+        self.md5_expected_value = '69399dbc48d587bd60a90e5cdc5d14a8'
+        self.md5_netcdf_value = md5(self.netcdf_tmp_file_path)
 
         self.assertEqual(self.md5_netcdf_value, self.md5_expected_value)
 
@@ -298,7 +317,8 @@ def args():
 if __name__ == '__main__':
     vargs = args()
     me = singleton.SingleInstance()
-    os.environ['data_wip_path'] = os.path.join(os.environ.get('WIP_DIR'), 'ANMN', 'NRS_AIMS_Darwin_Yongala_data_rss_download_temporary')
+    os.environ['data_wip_path'] = os.path.join(os.environ.get('WIP_DIR'), 'ANMN',
+                                               'NRS_AIMS_Darwin_Yongala_data_rss_download_temporary')
     global TMP_MANIFEST_DIR
     global TESTING
 
@@ -343,7 +363,7 @@ if __name__ == '__main__':
                 with open(incoming_dir_file, 'w') as manifest_file:
                     manifest_file.write("%s\n" % TMP_MANIFEST_DIR)
 
-                os.chmod(incoming_dir_file, 0664)  # change to 664 for pipeline v2
+                os.chmod(incoming_dir_file, 0o0664)  # change to 664 for pipeline v2
                 shutil.move(incoming_dir_file, os.path.join(ANMN_NRS_INCOMING_DIR, os.path.basename(incoming_dir_file)))
     else:
         logger.warning('Data validation unittests failed')

--- a/ANMN/NRS_AIMS/REALTIME/dest_path.py
+++ b/ANMN/NRS_AIMS/REALTIME/dest_path.py
@@ -1,99 +1,31 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Returns the relative path of a ANMN NRS NetCDF file
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-import os
-import re
-import sys
 
 from netCDF4 import Dataset
-
-
-def get_main_anmn_nrs_var(netcdf_file_path):
-    netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    variables       = netcdf_file_obj.variables.keys()
-    netcdf_file_obj.close()
-
-    del variables[variables.index('TIME')]
-    del variables[variables.index('LATITUDE')]
-    del variables[variables.index('LONGITUDE')]
-
-    if 'NOMINAL_DEPTH' in variables:
-        del variables[variables.index('NOMINAL_DEPTH')]
-
-    qc_var = [s for s in variables if '_quality_control' in s]
-    if qc_var != []:
-        del variables[variables.index(qc_var[0])]
-
-    return variables[0]
+from aims_realtime_util import get_main_netcdf_var
 
 
 def get_main_var_folder_name(netcdf_file_path):
-    main_var        = get_main_anmn_nrs_var(netcdf_file_path)
+    main_var = get_main_netcdf_var(netcdf_file_path)
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
     var_folder_name = netcdf_file_obj.variables[main_var].long_name.replace(' ', '_')
     aims_channel_id = netcdf_file_obj.aims_channel_id
 
     if hasattr(netcdf_file_obj.variables[main_var], 'sensor_depth'):
-        sensor_depth    = netcdf_file_obj.variables[main_var].sensor_depth
-        retval          = '%s@%sm_channel_%s' % (var_folder_name, str(sensor_depth), str(aims_channel_id))
+        sensor_depth = netcdf_file_obj.variables[main_var].sensor_depth
+        retval = '%s@%sm_channel_%s' % (var_folder_name, str(sensor_depth), str(aims_channel_id))
     else:
-        retval          = '%s_channel_%s' % (var_folder_name, str(aims_channel_id))
+        retval = '%s_channel_%s' % (var_folder_name, str(aims_channel_id))
 
     netcdf_file_obj.close()
     return retval
 
 
 def get_anmn_nrs_site_name(netcdf_file_path):
-    netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    site_code       = netcdf_file_obj.site_code
-    netcdf_file_obj.close()
-
-    return site_code
-
-
-def remove_md5_from_filename(netcdf_filename):
-    return re.sub('.nc.*$', '.nc', netcdf_filename)
-
-
-def add_site_code_to_filename(netcdf_filename, site_code):
-    return re.sub('(?=[^0-9]{6})Z_.*_FV0', 'Z_%s_FV0' % site_code, netcdf_filename)
-
-
-def create_file_hierarchy(netcdf_file_path):
-    netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    file_version    = netcdf_file_obj.file_version
-    main_var_folder = get_main_var_folder_name(netcdf_file_path)
-
-    if file_version == "Level 0 - Raw data":
-        level_name = 'NO_QAQC'
-    elif file_version == 'Level 1 - Quality Controlled Data':
-        level_name = 'QAQC'
-
-    year                 = netcdf_file_obj.time_coverage_start[0:4]
-    netcdf_file_obj.close()
-
-    site_code            = get_anmn_nrs_site_name(netcdf_file_path)
-    netcdf_filename      = remove_md5_from_filename(os.path.basename(netcdf_file_path))
-    netcdf_filename      = add_site_code_to_filename(netcdf_filename, site_code)
-    relative_netcdf_path = os.path.join('ANMN', 'NRS', 'REAL_TIME', site_code, main_var_folder, year, level_name, netcdf_filename)
-
-    return relative_netcdf_path
-
-
-if __name__ == '__main__':
-    # read filename from command line
-    if len(sys.argv) < 2:
-        print >>sys.stderr, 'No filename specified!'
-        exit(1)
-
-    destination_path = create_file_hierarchy(sys.argv[1])
-
-    if not destination_path:
-        exit(1)
-
-    print destination_path
-    exit(0)
+    with Dataset(netcdf_file_path, mode='r') as netcdf_file_obj:
+        return netcdf_file_obj.site_code

--- a/FAIMMS/REALTIME/dest_path.py
+++ b/FAIMMS/REALTIME/dest_path.py
@@ -1,47 +1,27 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Returns the relative path of a FAIMMS NetCDF file
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 
-import os
 import re
-import sys
 
 from netCDF4 import Dataset
-
-
-def get_main_faimms_var(netcdf_file_path):
-    netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    variables       = netcdf_file_obj.variables.keys()
-    netcdf_file_obj.close()
-
-    del variables[variables.index('TIME')]
-    del variables[variables.index('LATITUDE')]
-    del variables[variables.index('LONGITUDE')]
-
-    if 'NOMINAL_DEPTH' in variables:
-        del variables[variables.index('NOMINAL_DEPTH')]
-
-    qc_var = [s for s in variables if '_quality_control' in s]
-    if qc_var != []:
-        del variables[variables.index(qc_var[0])]
-
-    return variables[0]
+from aims_realtime_util import get_main_netcdf_var
 
 
 def get_main_var_folder_name(netcdf_file_path):
-    main_var        = get_main_faimms_var(netcdf_file_path)
+    main_var = get_main_netcdf_var(netcdf_file_path)
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
     var_folder_name = netcdf_file_obj.variables[main_var].long_name.replace(' ', '_')
     aims_channel_id = netcdf_file_obj.aims_channel_id
 
     if hasattr(netcdf_file_obj.variables[main_var], 'sensor_depth'):
-        sensor_depth    = netcdf_file_obj.variables[main_var].sensor_depth
-        retval          = '%s@%sm_channel_%s' % (var_folder_name, str(sensor_depth), str(aims_channel_id))
+        sensor_depth = netcdf_file_obj.variables[main_var].sensor_depth
+        retval = '%s@%sm_channel_%s' % (var_folder_name, str(sensor_depth), str(aims_channel_id))
     else:
-        retval          = '%s_channel_%s' % (var_folder_name, str(aims_channel_id))
+        retval = '%s_channel_%s' % (var_folder_name, str(aims_channel_id))
 
     netcdf_file_obj.close()
     return retval
@@ -49,7 +29,7 @@ def get_main_var_folder_name(netcdf_file_path):
 
 def get_faimms_site_name(netcdf_file_path):
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    site_code       = netcdf_file_obj.site_code
+    site_code = netcdf_file_obj.site_code
     netcdf_file_obj.close()
 
     if 'DAV' in site_code:
@@ -72,7 +52,7 @@ def get_faimms_site_name(netcdf_file_path):
 
 def get_faimms_platform_type(netcdf_file_path):
     netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    site_code       = netcdf_file_obj.site_code
+    site_code = netcdf_file_obj.site_code
     netcdf_file_obj.close()
 
     if 'SF' in site_code:
@@ -85,57 +65,3 @@ def get_faimms_platform_type(netcdf_file_path):
         return 'Weather_Station_Platform'
     else:
         return []
-
-
-def get_main_faimms_site_name_path(netcdf_file_path):
-    site_name     = get_faimms_site_name(netcdf_file_path)
-    platform_type = get_faimms_platform_type(netcdf_file_path)
-
-    if site_name == []:
-        print >>sys.stderr, 'Unknown site name'
-        exit(1)
-
-    if platform_type == []:
-        print >>sys.stderr, 'Unknown platform type'
-        exit(1)
-
-    return os.path.join(site_name, platform_type)
-
-
-def remove_md5_from_filename(netcdf_filename):
-    return re.sub('.nc.*$', '.nc', netcdf_filename)
-
-
-def create_file_hierarchy(netcdf_file_path):
-    netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    file_version    = netcdf_file_obj.file_version
-    main_var_folder = get_main_var_folder_name(netcdf_file_path)
-
-    if file_version == "Level 0 - Raw data":
-        level_name = 'NO_QAQC'
-    elif file_version == 'Level 1 - Quality Controlled Data':
-        level_name = 'QAQC'
-
-    year                 = netcdf_file_obj.time_coverage_start[0:4]
-    netcdf_file_obj.close()
-
-    site_name_path       = get_main_faimms_site_name_path(netcdf_file_path)
-    netcdf_filename      = remove_md5_from_filename(os.path.basename(netcdf_file_path))
-    relative_netcdf_path = os.path.join('FAIMMS', site_name_path, main_var_folder, year, level_name, netcdf_filename)
-
-    return relative_netcdf_path
-
-
-if __name__ == '__main__':
-    # read filename from command line
-    if len(sys.argv) < 2:
-        print >>sys.stderr, 'No filename specified!'
-        exit(1)
-
-    destination_path = create_file_hierarchy(sys.argv[1])
-
-    if not destination_path:
-        exit(1)
-
-    print destination_path
-    exit(0)

--- a/FAIMMS/REALTIME/faimms.py
+++ b/FAIMMS/REALTIME/faimms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Download FAIMMS data from AIMS Web Service
@@ -33,6 +33,7 @@ import shutil
 import traceback
 import unittest as data_validation_test
 
+from dest_path import get_faimms_platform_type, get_faimms_site_name
 from netCDF4 import Dataset
 from tendo import singleton
 
@@ -46,9 +47,7 @@ from aims_realtime_util import (close_logger, convert_time_cf_to_imos,
                                 modify_aims_netcdf, parse_aims_xml,
                                 remove_dimension_from_netcdf,
                                 remove_end_date_from_filename, save_channel_info,
-                                set_up, rm_tmp_dir)
-from dest_path import (get_faimms_platform_type, get_faimms_site_name,
-                       get_main_faimms_var)
+                                set_up, rm_tmp_dir, get_main_netcdf_var)
 from util import pass_netcdf_checker
 
 DATA_WIP_PATH = os.path.join(os.environ.get('WIP_DIR'), 'FAIMMS', 'REALTIME')
@@ -64,7 +63,7 @@ def modify_faimms_netcdf(netcdf_file_path, channel_id_info):
     """
     modify_aims_netcdf(netcdf_file_path, channel_id_info)
 
-    netcdf_file_obj                 = Dataset(netcdf_file_path, 'a', format='NETCDF4')
+    netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')
     netcdf_file_obj.aims_channel_id = int(channel_id_info['channel_id'])
 
     if not (channel_id_info['metadata_uuid'] == 'Not Available'):
@@ -72,27 +71,28 @@ def modify_faimms_netcdf(netcdf_file_path, channel_id_info):
 
     # some weather stations channels don't have a depth variable if sensor above water
     if 'depth' in netcdf_file_obj.variables.keys():
-        var                 = netcdf_file_obj.variables['depth']
-        var.long_name       = 'nominal depth'
-        var.positive        = 'down'
-        var.axis            = 'Z'
+        var = netcdf_file_obj.variables['depth']
+        var.long_name = 'nominal depth'
+        var.positive = 'down'
+        var.axis = 'Z'
         var.reference_datum = 'sea surface'
-        var.valid_min       = -10.0
-        var.valid_max       = 30.0
+        var.valid_min = -10.0
+        var.valid_max = 30.0
         netcdf_file_obj.renameVariable('depth', 'NOMINAL_DEPTH')
 
     if 'DEPTH' in netcdf_file_obj.variables.keys():
-        var                 = netcdf_file_obj.variables['DEPTH']
-        var.coordinates     = "TIME LATITUDE LONGITUDE NOMINAL_DEPTH"
-        var.long_name       = 'actual depth'
+        var = netcdf_file_obj.variables['DEPTH']
+        var.coordinates = "TIME LATITUDE LONGITUDE NOMINAL_DEPTH"
+        var.long_name = 'actual depth'
         var.reference_datum = 'sea surface'
-        var.positive        = 'down'
-        var.valid_min       = -10.0
-        var.valid_max       = 30.0
+        var.positive = 'down'
+        var.valid_min = -10.0
+        var.valid_max = 30.0
 
     netcdf_file_obj.close()
-    netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')  # need to close to save to file. as we call get_main_faimms_var just after
-    main_var        = get_main_faimms_var(netcdf_file_path)
+    netcdf_file_obj = Dataset(netcdf_file_path, 'a',
+                              format='NETCDF4')  # need to close to save to file. as we call get_main_netcdf_var just after
+    main_var = get_main_netcdf_var(netcdf_file_path)
     # DEPTH, LATITUDE and LONGITUDE are not dimensions, so we make them into auxiliary cooordinate variables by adding this attribute
     if 'NOMINAL_DEPTH' in netcdf_file_obj.variables.keys():
         netcdf_file_obj.variables[main_var].coordinates = "TIME LATITUDE LONGITUDE NOMINAL_DEPTH"
@@ -113,7 +113,7 @@ def move_to_tmp_incoming(netcdf_path):
     new_filename = '%s.%s.nc' % (os.path.splitext(os.path.basename(remove_end_date_from_filename(netcdf_path)))[0],
                                  md5(netcdf_path))
 
-    os.chmod(netcdf_path, 0664)  # change to 664 for pipeline v2
+    os.chmod(netcdf_path, 0o0664)  # change to 664 for pipeline v2
     shutil.move(netcdf_path, os.path.join(TMP_MANIFEST_DIR, new_filename))
 
 
@@ -137,10 +137,10 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
     if len(start_dates) != 0:
         # download monthly file
         for start_date, end_date in zip(start_dates, end_dates):
-            start_date           = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
-            end_date             = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            start_date = start_date.strftime("%Y-%m-%dT%H:%M:%SZ")
+            end_date = end_date.strftime("%Y-%m-%dT%H:%M:%SZ")
             netcdf_tmp_file_path = download_channel(channel_id, start_date, end_date, level_qc)
-            contact_aims_msg     = "Process of channel aborted - CONTACT AIMS"
+            contact_aims_msg = "Process of channel aborted - CONTACT AIMS"
 
             if netcdf_tmp_file_path is None:
                 logger.error('   Channel %s - not valid zip file - %s' % (str(channel_id), contact_aims_msg))
@@ -148,32 +148,39 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
 
             # NO_DATA_FOUND file only means there is no data for the selected time period. Could be some data afterwards
             if is_no_data_found(netcdf_tmp_file_path):
-                logger.warning('   Channel %s - No data for the time period:%s - %s' % (str(channel_id), start_date, end_date))
+                logger.warning(
+                    '   Channel %s - No data for the time period:%s - %s' % (str(channel_id), start_date, end_date))
                 shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
             else:
                 if is_time_var_empty(netcdf_tmp_file_path):
-                    logger.error('   Channel %s - No values in TIME variable - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error(
+                        '   Channel %s - No values in TIME variable - %s' % (str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
                 if not modify_faimms_netcdf(netcdf_tmp_file_path, channel_id_info):
-                    logger.error('   Channel %s - Could not modify the NetCDF file - Process of channel aborted' % str(channel_id))
+                    logger.error('   Channel %s - Could not modify the NetCDF file - Process of channel aborted' % str(
+                        channel_id))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
-                main_var = get_main_faimms_var(netcdf_tmp_file_path)
+                main_var = get_main_netcdf_var(netcdf_tmp_file_path)
                 if has_var_only_fill_value(netcdf_tmp_file_path, main_var):
-                    logger.error('   Channel %s - _Fillvalues only in main variable - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error(
+                        '   Channel %s - _Fillvalues only in main variable - %s' % (str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
-                if get_faimms_site_name(netcdf_tmp_file_path) == [] or get_faimms_platform_type(netcdf_tmp_file_path) == []:
-                    logger.error('   Channel %s - Unknown site_code gatt value - %s' % (str(channel_id), contact_aims_msg))
+                if get_faimms_site_name(netcdf_tmp_file_path) == [] or get_faimms_platform_type(
+                        netcdf_tmp_file_path) == []:
+                    logger.error(
+                        '   Channel %s - Unknown site_code gatt value - %s' % (str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
                 if not is_time_monotonic(netcdf_tmp_file_path):
-                    logger.error('   Channel %s - TIME value is not strickly monotonic - %s' % (str(channel_id), contact_aims_msg))
+                    logger.error('   Channel %s - TIME value is not strickly monotonic - %s' % (
+                        str(channel_id), contact_aims_msg))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
@@ -181,9 +188,12 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
                 wip_path = DATA_WIP_PATH
                 checker_retval = pass_netcdf_checker(netcdf_tmp_file_path, tests=['cf:latest', 'imos:1.3'])
                 if not checker_retval:
-                    logger.error('   Channel %s - File does not pass CF/IMOS compliance checker - Process of channel aborted' % str(channel_id))
+                    logger.error(
+                        '   Channel %s - File does not pass CF/IMOS compliance checker - Process of channel aborted' % str(
+                            channel_id))
                     shutil.copy(netcdf_tmp_file_path, os.path.join(wip_path, 'errors'))
-                    logger.error('   File copied to %s for debugging' % (os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
+                    logger.error('   File copied to %s for debugging' % (
+                        os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
 
@@ -191,9 +201,12 @@ def process_monthly_channel(channel_id, aims_xml_info, level_qc):
                 netcdf_tmp_file_path = fix_provider_code_from_filename(netcdf_tmp_file_path, 'IMOS_FAIMMS')
 
                 if re.search('IMOS_FAIMMS_[A-Z]{1}_', netcdf_tmp_file_path) is None:
-                    logger.error('   Channel %s - File name Data code does not pass REGEX - Process of channel aborted' % str(channel_id))
+                    logger.error(
+                        '   Channel %s - File name Data code does not pass REGEX - Process of channel aborted' % str(
+                            channel_id))
                     shutil.copy(netcdf_tmp_file_path, os.path.join(wip_path, 'errors'))
-                    logger.error('   File copied to %s for debugging' % (os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
+                    logger.error('   File copied to %s for debugging' % (
+                        os.path.join(wip_path, 'errors', os.path.basename(netcdf_tmp_file_path))))
                     shutil.rmtree(os.path.dirname(netcdf_tmp_file_path))
                     break
                 move_to_tmp_incoming(netcdf_tmp_file_path)
@@ -220,15 +233,17 @@ def process_qc_level(level_qc):
     xml_url = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/1' % str(level_qc)
     try:
         aims_xml_info = parse_aims_xml(xml_url)
-    except:
+    except Exception as err:
         logger.error('RSS feed not available')
         exit(1)
 
     for channel_id in aims_xml_info.keys():
         try:
             process_monthly_channel(channel_id, aims_xml_info, level_qc)
-        except Exception, e:
-            logger.error('   Channel %s QC%s - Failed, unknown reason - manual debug required' % (str(channel_id), str(level_qc)))
+        except Exception as err:
+            logger.error('   Channel {channel_id} QC{level_qc} - Failed, unknown reason - manual debug required'.
+                         format(channel_id=str(channel_id),
+                                level_qc=str(level_qc)))
             logger.error(traceback.print_exc())
 
 
@@ -239,31 +254,33 @@ class AimsDataValidationTest(data_validation_test.TestCase):
         This function checks that a downloaded file still has the same md5.
         """
         logging_aims()
-        channel_id                   = '9272'
-        from_date                    = '2016-01-01T00:00:00Z'
-        thru_date                    = '2016-01-02T00:00:00Z'
-        level_qc                     = 1
-        faimms_rss_val               = 1
-        xml_url                      = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/%s' % (str(level_qc), str(faimms_rss_val))
+        channel_id = '9272'
+        from_date = '2016-01-01T00:00:00Z'
+        thru_date = '2016-01-02T00:00:00Z'
+        level_qc = 1
+        faimms_rss_val = 1
+        xml_url = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/%s' % (
+            str(level_qc), str(faimms_rss_val))
 
-        aims_xml_info                = parse_aims_xml(xml_url)
+        aims_xml_info = parse_aims_xml(xml_url)
         channel_id_info = aims_xml_info[channel_id]
-        self.netcdf_tmp_file_path    = download_channel(channel_id, from_date, thru_date, level_qc)
+        self.netcdf_tmp_file_path = download_channel(channel_id, from_date, thru_date, level_qc)
         modify_faimms_netcdf(self.netcdf_tmp_file_path, channel_id_info)
 
         # force values of attributes which change all the time
-        netcdf_file_obj              = Dataset(self.netcdf_tmp_file_path, 'a', format='NETCDF4')
+        netcdf_file_obj = Dataset(self.netcdf_tmp_file_path, 'a', format='NETCDF4')
         netcdf_file_obj.date_created = "1970-01-01T00:00:00Z"  # epoch
-        netcdf_file_obj.history      = 'data validation test only'
+        netcdf_file_obj.history = 'data validation test only'
         netcdf_file_obj.close()
 
     def tearDown(self):
-        shutil.copy(self.netcdf_tmp_file_path, os.path.join(DATA_WIP_PATH, 'nc_unittest_%s.nc' % self.md5_netcdf_value))
+        shutil.copy(self.netcdf_tmp_file_path,
+                    os.path.join(DATA_WIP_PATH, 'nc_unittest_{md5_val}.nc'.format(md5_val=self.md5_netcdf_value)))
         shutil.rmtree(os.path.dirname(self.netcdf_tmp_file_path))
 
     def test_aims_validation(self):
-        self.md5_expected_value = '20eeb53140d06e9cbea7e941caa108b5'
-        self.md5_netcdf_value   = md5(self.netcdf_tmp_file_path)
+        self.md5_expected_value = '67f116b43dd8592373fb94438e619d93'
+        self.md5_netcdf_value = md5(self.netcdf_tmp_file_path)
 
         self.assertEqual(self.md5_netcdf_value, self.md5_expected_value)
 
@@ -329,7 +346,7 @@ if __name__ == '__main__':
                 with open(incoming_dir_file, 'w') as manifest_file:
                     manifest_file.write("%s\n" % TMP_MANIFEST_DIR)
 
-                os.chmod(incoming_dir_file, 0664)  # change to 664 for pipeline v2
+                os.chmod(incoming_dir_file, 0o0664)  # change to 664 for pipeline v2
                 shutil.move(incoming_dir_file, os.path.join(FAIMMS_INCOMING_DIR, os.path.basename(incoming_dir_file)))
     else:
         logger.warning('Data validation unittests failed')

--- a/SOOP/SOOP_ASF_SST_XBT/SOOP_BOM_ASF_SST.py
+++ b/SOOP/SOOP_ASF_SST_XBT/SOOP_BOM_ASF_SST.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 
 import argparse
@@ -70,8 +70,10 @@ def parse_arg():
     """
     parser = argparse.ArgumentParser()
     parser.add_argument("-f", "--force-push-incoming",
-                        help="force the push of all files alreay downloaded to the incoming dir. Does not download new ones", action="store_true")
-    parser.add_argument("-r", "--reprocess-files-match-pattern", type=str, help="reprocess all files already downloaded matching a string pattern. '*SOOP-SST*' '*FHZI*' ... to the incoming dir", )
+                        help="force the push of all files alreay downloaded to the incoming dir. Does not download new ones",
+                        action="store_true")
+    parser.add_argument("-r", "--reprocess-files-match-pattern", type=str,
+                        help="reprocess all files already downloaded matching a string pattern. '*SOOP-SST*' '*FHZI*' ... to the incoming dir", )
     parser.add_argument("-d", "--dry-run", help="to use with -r option. Performs a dry-run", action="store_true")
     args = parser.parse_args()
 

--- a/SOOP/SOOP_ASF_SST_XBT/SOOP_XBT_NRT.py
+++ b/SOOP/SOOP_ASF_SST_XBT/SOOP_XBT_NRT.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """ Download SBD files from CSIRO FTP and convert to NETCDF
 The NETCDF files are then pushed to the INCOMING_DIR
@@ -21,25 +21,25 @@ from util import list_files_recursively
 def main(force_reprocess_all=False):
     # will sys.exit(-1) if other instance is running
     me = singleton.SingleInstance()
-    wip_soop_path    = os.path.join(os.environ['WIP_DIR'], 'SOOP',
-                                    'SOOP_XBT_ASF_SST')
+    wip_soop_path = os.path.join(os.environ['WIP_DIR'], 'SOOP',
+                                 'SOOP_XBT_ASF_SST')
     lftp_output_path = os.path.join(wip_soop_path, 'data_unsorted', 'XBT',
                                     'sbddata')
-    csv_output_path  = os.path.join(wip_soop_path, 'data_sorted', 'XBT',
-                                    'sbddata')
-    log_filepath     = os.path.join(wip_soop_path, 'soop_xbt.log')
-    logging          = IMOSLogging()
-    logger           = logging.logging_start(log_filepath)
+    csv_output_path = os.path.join(wip_soop_path, 'data_sorted', 'XBT',
+                                   'sbddata')
+    log_filepath = os.path.join(wip_soop_path, 'soop_xbt.log')
+    logging = IMOSLogging()
+    logger = logging.logging_start(log_filepath)
 
     lftp_access = {
-        'ftp_address'     : os.environ['IMOS_PO_CREDS_CSIRO_IT_FTP_ADDRESS'],
-        'ftp_subdir'      : '/',
-        'ftp_user'        : os.environ['IMOS_PO_CREDS_CSIRO_IT_FTP_USERNAME'],
-        'ftp_password'    : os.environ['IMOS_PO_CREDS_CSIRO_IT_FTP_PASSWORD'],
-        'ftp_exclude_dir' : '',
-        'lftp_options'    : '--only-newer',
-        'output_dir'      : lftp_output_path
-        }
+        'ftp_address': os.environ['IMOS_PO_CREDS_CSIRO_IT_FTP_ADDRESS'],
+        'ftp_subdir': '/',
+        'ftp_user': os.environ['IMOS_PO_CREDS_CSIRO_IT_FTP_USERNAME'],
+        'ftp_password': os.environ['IMOS_PO_CREDS_CSIRO_IT_FTP_PASSWORD'],
+        'ftp_exclude_dir': '',
+        'lftp_options': '--only-newer',
+        'output_dir': lftp_output_path
+    }
 
     lftp = LFTPSync()
     logger.info('Download new SOOP XBT NRT files')
@@ -52,7 +52,7 @@ def main(force_reprocess_all=False):
         list_new_files = lftp.list_new_files_path(check_file_exist=True)
 
     logger.info('Convert SBD files to CSV')
-    processSBD    = soop_xbt_realtime_processSBD()
+    processSBD = soop_xbt_realtime_processSBD()
     manifest_list = []
     for f in list_new_files:
         if f.endswith(".sbd"):
@@ -60,13 +60,13 @@ def main(force_reprocess_all=False):
                 csv_file = processSBD.handle_sbd_file(f, csv_output_path)
                 if csv_file not in manifest_list:
                     manifest_list.append(csv_file)
-            except Exception, e:
-                logger.error(str(e))
+            except Exception as err:
+                logger.error(str(err))
                 pass
 
     fd, manifest_file = mkstemp()
     for csv_file in manifest_list:
-        if not(csv_file == []):
+        if not (csv_file == []):
             os.write(fd, '%s\n' % csv_file)
     os.close(fd)
     os.chmod(manifest_file, 0o664)  # since msktemp creates 600 for security
@@ -83,6 +83,7 @@ def main(force_reprocess_all=False):
 
     lftp.close()
     logging.logging_stop()
+
 
 def parse_arg():
     """

--- a/SOOP/SOOP_ASF_SST_XBT/subroutines/soop_xbt_realtime_processSBD.py
+++ b/SOOP/SOOP_ASF_SST_XBT/subroutines/soop_xbt_realtime_processSBD.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Process SBD binary files

--- a/SOOP/SOOP_TRV/dest_path.py
+++ b/SOOP/SOOP_TRV/dest_path.py
@@ -3,10 +3,8 @@
 #
 # author Laurent Besnard, laurent.besnard@utas.edu.au
 
-import datetime
-import os
+
 import re
-import sys
 
 from netCDF4 import Dataset
 
@@ -41,36 +39,3 @@ def get_main_var_folder_name(netcdf_file_path):
 
 def remove_creation_date_from_filename(netcdf_filename):
     return re.sub('_C-.*$', '.nc', netcdf_filename)
-
-
-def create_file_hierarchy(netcdf_file_path):
-    netcdf_file_obj = Dataset(netcdf_file_path, mode='r')
-    ship_code       = netcdf_file_obj.platform_code
-    vessel_name     = netcdf_file_obj.vessel_name
-    main_var_folder = get_main_var_folder_name(netcdf_file_path)
-
-    date_start = datetime.datetime.strptime(netcdf_file_obj.time_coverage_start, "%Y-%m-%dT%H:%M:%SZ")
-    date_start = date_start.strftime('%Y%m%dT%H%M%SZ')
-    date_end   = datetime.datetime.strptime(netcdf_file_obj.time_coverage_end, "%Y-%m-%dT%H:%M:%SZ")
-    date_end   = date_end.strftime('%Y%m%dT%H%M%SZ')
-
-    netcdf_filename      = remove_creation_date_from_filename(os.path.basename(netcdf_file_path))
-    relative_netcdf_path = os.path.join('SOOP', 'SOOP-TRV', '%s_%s' % (ship_code, vessel_name), 'By_Cruise', 'Cruise_START-%s_END-%s' % (date_start, date_end), main_var_folder, netcdf_filename)
-
-    netcdf_file_obj.close()
-    return relative_netcdf_path
-
-
-if __name__ == '__main__':
-    # read filename from command line
-    if len(sys.argv) < 2:
-        print >>sys.stderr, 'No filename specified!'
-        exit(1)
-
-    destination_path = create_file_hierarchy(sys.argv[1])
-
-    if not destination_path:
-        exit(1)
-
-    print destination_path
-    exit(0)

--- a/SOOP/SOOP_TRV/soop_trv.py
+++ b/SOOP/SOOP_TRV/soop_trv.py
@@ -44,8 +44,8 @@ def modify_soop_trv_netcdf(netcdf_file_path, channel_id_info):
 
     modify_aims_netcdf(netcdf_file_path, channel_id_info)
     netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')
-    ship_code       = netcdf_file_obj.platform_code
-    vessel_name     = ship_callsign(ship_code)
+    ship_code = netcdf_file_obj.platform_code
+    vessel_name = ship_callsign(ship_code)
 
     if vessel_name is None:
         logger.error('   UNKNOWN SHIP - channel %s' % str(channel_id_info['channel_id']))
@@ -54,38 +54,38 @@ def modify_soop_trv_netcdf(netcdf_file_path, channel_id_info):
 
     # add gatts to net_cDF
     netcdf_file_obj.cdm_data_type = 'Trajectory'
-    netcdf_file_obj.vessel_name   = vessel_name
-    netcdf_file_obj.trip_id       = channel_id_info['trip_id']
+    netcdf_file_obj.vessel_name = vessel_name
+    netcdf_file_obj.trip_id = channel_id_info['trip_id']
     netcdf_file_obj.cdm_data_type = "Trajectory"
-    coordinates_att               = "TIME LATITUDE LONGITUDE DEPTH"
+    coordinates_att = "TIME LATITUDE LONGITUDE DEPTH"
 
     # depth
-    depth                 = netcdf_file_obj.variables['depth']
-    depth.positive        = 'down'
-    depth.axis            = 'Z'
+    depth = netcdf_file_obj.variables['depth']
+    depth.positive = 'down'
+    depth.axis = 'Z'
     depth.reference_datum = 'sea surface'
-    depth.valid_max       = 30.0
-    depth.valid_min       = -10.0
+    depth.valid_max = 30.0
+    depth.valid_min = -10.0
     netcdf_file_obj.renameVariable('depth', 'DEPTH')
 
     # latitude longitude
-    latitude                      = netcdf_file_obj.variables['LATITUDE']
-    latitude.ancillary_variables  = 'LATITUDE_quality_control'
+    latitude = netcdf_file_obj.variables['LATITUDE']
+    latitude.ancillary_variables = 'LATITUDE_quality_control'
 
-    longitude                     = netcdf_file_obj.variables['LONGITUDE']
+    longitude = netcdf_file_obj.variables['LONGITUDE']
     longitude.ancillary_variables = 'LONGITUDE_quality_control'
 
-    latitude_qc                   = netcdf_file_obj.variables['LATITUDE_quality_control']
-    latitude_qc.long_name         = 'LATITUDE quality control'
-    latitude_qc.standard_name     = 'latitude status_flag'
-    longitude_qc                  = netcdf_file_obj.variables['LONGITUDE_quality_control']
-    longitude_qc.long_name        = 'LONGITUDE quality control'
-    longitude_qc.standard_name    = 'longitude status_flag'
+    latitude_qc = netcdf_file_obj.variables['LATITUDE_quality_control']
+    latitude_qc.long_name = 'LATITUDE quality control'
+    latitude_qc.standard_name = 'latitude status_flag'
+    longitude_qc = netcdf_file_obj.variables['LONGITUDE_quality_control']
+    longitude_qc.long_name = 'LONGITUDE quality control'
+    longitude_qc.standard_name = 'longitude status_flag'
 
     netcdf_file_obj.close()
 
     netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')
-    main_var        = get_main_soop_trv_var(netcdf_file_path)
+    main_var = get_main_soop_trv_var(netcdf_file_path)
     netcdf_file_obj.variables[main_var].coordinates = coordinates_att
 
     netcdf_file_obj.close()
@@ -103,15 +103,15 @@ def _is_lat_lon_values_outside_boundaries(netcdf_file_path):
     really easy way to check this
     netcdf_file_path9str) : path of the netcdf file to check"""
     netcdf_file_obj = Dataset(netcdf_file_path, 'a', format='NETCDF4')
-    lat             = netcdf_file_obj.variables['LATITUDE'][:]
-    lon             = netcdf_file_obj.variables['LONGITUDE'][:]
+    lat = netcdf_file_obj.variables['LATITUDE'][:]
+    lon = netcdf_file_obj.variables['LONGITUDE'][:]
     netcdf_file_obj.close()
 
     return any(lat > 0) or any(lat < -50) or any(lon > 180) or any(lon < 0)
 
 
 def move_to_incoming(netcdf_path):
-    incoming_dir      = os.environ.get('INCOMING_DIR')
+    incoming_dir = os.environ.get('INCOMING_DIR')
     soop_incoming_dir = os.path.join(incoming_dir, 'SOOP/TRV',
                                      os.path.basename(netcdf_path))
 
@@ -138,7 +138,7 @@ def process_channel(channel_id, aims_xml_info, level_qc):
                                                          str(channel_id)))
 
         if datetime.strptime(thru_date, "%Y-%m-%dT%H:%M:%SZ") > \
-            datetime.strptime(thru_date_already_downloaded, "%Y-%m-%dT%H:%M:%SZ"):
+                datetime.strptime(thru_date_already_downloaded, "%Y-%m-%dT%H:%M:%SZ"):
             logger.info('>> QC%s - New data available for channel %s.\nLatest date downloaded: %s'
                         ' \nNew date available: %s' % (str(level_qc),
                                                        str(channel_id),
@@ -147,7 +147,7 @@ def process_channel(channel_id, aims_xml_info, level_qc):
 
         netcdf_tmp_file_path = download_channel(channel_id, from_date,
                                                 thru_date, level_qc)
-        contact_aims_msg     = "Process of channel aborted - CONTACT AIMS"
+        contact_aims_msg = "Process of channel aborted - CONTACT AIMS"
 
         if netcdf_tmp_file_path is None:
             logger.error('   Channel %s - not valid zip file - %s'
@@ -226,11 +226,11 @@ def process_qc_level(level_qc):
                                                    level_qc)
             if is_channel_processed:
                 save_channel_info(channel_id, aims_xml_info, level_qc)
-        except Exception, e:
+        except Exception as err:
             logger.error('   Channel %s QC%s - Failed, unknown reason - manual \
                          debug required' % (str(channel_id), str(level_qc)))
 
-            logger.error(str(e))
+            logger.error(str(err))
             logger.error(traceback.print_exc())
 
 
@@ -241,40 +241,42 @@ class AimsDataValidationTest(data_validation_test.TestCase):
         This function checks that a downloaded file still has the same md5.
         """
         logging_aims()
-        channel_id                   = '8365'
-        from_date                    = '2008-09-30T00:27:27Z'
-        thru_date                    = '2008-09-30T00:30:00Z'
-        level_qc                     = 1
-        aims_rss_val                 = 100
-        xml_url                      = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/%s' % (str(level_qc), str(aims_rss_val))
+        channel_id = '8365'
+        from_date = '2008-09-30T00:27:27Z'
+        thru_date = '2008-09-30T00:30:00Z'
+        level_qc = 1
+        aims_rss_val = 100
+        xml_url = 'http://data.aims.gov.au/gbroosdata/services/rss/netcdf/level%s/%s' % (
+        str(level_qc), str(aims_rss_val))
 
-        aims_xml_info                = parse_aims_xml(xml_url)
+        aims_xml_info = parse_aims_xml(xml_url)
         channel_id_info = aims_xml_info[channel_id]
-        self.netcdf_tmp_file_path    = download_channel(channel_id, from_date, thru_date, level_qc)
+        self.netcdf_tmp_file_path = download_channel(channel_id, from_date, thru_date, level_qc)
         modify_soop_trv_netcdf(self.netcdf_tmp_file_path, channel_id_info)
 
         # force values of attributes which change all the time
-        netcdf_file_obj              = Dataset(self.netcdf_tmp_file_path, 'a', format='NETCDF4')
+        netcdf_file_obj = Dataset(self.netcdf_tmp_file_path, 'a', format='NETCDF4')
         netcdf_file_obj.date_created = "1970-01-01T00:00:00Z"
-        netcdf_file_obj.history      = 'data validation test only'
+        netcdf_file_obj.history = 'data validation test only'
         netcdf_file_obj.close()
 
         shutil.move(self.netcdf_tmp_file_path, remove_creation_date_from_filename(self.netcdf_tmp_file_path))
-        self.netcdf_tmp_file_path    = remove_creation_date_from_filename(self.netcdf_tmp_file_path)
+        self.netcdf_tmp_file_path = remove_creation_date_from_filename(self.netcdf_tmp_file_path)
 
     def tearDown(self):
-        shutil.copy(self.netcdf_tmp_file_path, os.path.join(os.environ['data_wip_path'], 'nc_unittest_%s.nc' % self.md5_netcdf_value))
+        shutil.copy(self.netcdf_tmp_file_path,
+                    os.path.join(os.environ['data_wip_path'], 'nc_unittest_%s.nc' % self.md5_netcdf_value))
         shutil.rmtree(os.path.dirname(self.netcdf_tmp_file_path))
 
     def test_aims_validation(self):
-        self.md5_expected_value = '18770178cd71c228e8b59ccba3c7b8b5'
-        self.md5_netcdf_value   = md5(self.netcdf_tmp_file_path)
+        self.md5_expected_value = '3464ee1a8bcd600645b6cdb7516fd9e4'
+        self.md5_netcdf_value = md5(self.netcdf_tmp_file_path)
 
         self.assertEqual(self.md5_netcdf_value, self.md5_expected_value)
 
 
 if __name__ == '__main__':
-    me  = singleton.SingleInstance()
+    me = singleton.SingleInstance()
     os.environ['data_wip_path'] = os.path.join(os.environ.get('WIP_DIR'), 'SOOP', 'SOOP_TRV_RSS_Download_temporary')
     set_up()
     res = data_validation_test.main(exit=False)

--- a/SRS/SRS_OC_LJCO_AERONET/download_aeronet.py
+++ b/SRS/SRS_OC_LJCO_AERONET/download_aeronet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Created on Tue Oct  7 11:45:44 2014
@@ -14,22 +14,23 @@ import os
 import re
 import shutil
 import sys
-import urllib2
 import zipfile
-from StringIO import StringIO
+from io import BytesIO
 from tempfile import mkdtemp, mkstemp
-from urllib import urlopen
+from urllib.request import urlopen
 
-from BeautifulSoup import BeautifulSoup
+from bs4 import BeautifulSoup
 
 from imos_logging import IMOSLogging
 
 NASA_LEV2_URL = "http://aeronet.gsfc.nasa.gov/cgi-bin/print_warning_opera_v2_new?site=Lucinda&year=110&month=6&day=1&year2=110&month2=6&day2=30&LEV20=1&AVG=10"
 
+
 def download_ljco_aeronet(download_dir):
     logger.info('Open NASA webpage')
-    htmlPage     = urllib2.urlopen(NASA_LEV2_URL)
-    htmlPageSoup = BeautifulSoup(htmlPage)
+    with urlopen(NASA_LEV2_URL) as response:
+        html = response
+        htmlPageSoup = BeautifulSoup(html.read(), 'html.parser')
 
     # scrap webpage to find zip file address
     webpageBase, value = NASA_LEV2_URL.split("/cgi-bin", 1)
@@ -38,15 +39,15 @@ def download_ljco_aeronet(download_dir):
 
     logger.info('Downloading AERONET data')
     url_data_object = urlopen(dataWebLink)
-    temp_dir        = mkdtemp()
+    temp_dir = mkdtemp()
 
-    with zipfile.ZipFile(StringIO(url_data_object.read())) as zip_data:
+    with zipfile.ZipFile(BytesIO(url_data_object.read())) as zip_data:
         zip_data.extractall(temp_dir)
 
-    data_file    = glob.glob('%s/*Lucinda.lev20' % temp_dir)[0]
+    data_file = glob.glob('%s/*Lucinda.lev20' % temp_dir)[0]
 
     logger.info('Cleaning AERONET data')
-    f        = open(data_file, 'r')
+    f = open(data_file, 'r')
     filedata = f.read()
     f.close()
 
@@ -72,8 +73,8 @@ if __name__ == "__main__":
 
     try:
         download_ljco_aeronet(sys.argv[1])
-    except Exception, e:
-        print e
+    except Exception as err:
+        print(err)
 
     logging.logging_stop()
     os.close(log_file[0][0])

--- a/lib/python/imos_logging.py
+++ b/lib/python/imos_logging.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 """
 Class to simplify and standardise within eMII the use of the logging library for
 Python
@@ -29,7 +29,7 @@ class IMOSLogging():
 
     def __init__(self):
         self.logging_filepath = []
-        self.logger           = []
+        self.logger = []
 
     def logging_start(self, logging_filepath):
         """ start logging using logging python library
@@ -58,7 +58,7 @@ class IMOSLogging():
 
     def logging_stop(self):
         """ close logging """
-        #closes the handlers of the specified logger only
+        # closes the handlers of the specified logger only
         x = list(self.logger.handlers)
         for i in x:
             self.logger.removeHandler(i)

--- a/lib/python/lftp_sync.py
+++ b/lib/python/lftp_sync.py
@@ -114,8 +114,8 @@ class LFTPSync:
 
         try:
             os.system(cmd)
-        except Exception, e:
-            print str(e)
+        except Exception as err:
+            print(str(err))
 
         self.chmod_path(self.output_dir)
 
@@ -131,7 +131,7 @@ class LFTPSync:
             self.lftp_subdir = self.lftp_subdir[1:]  # to avoid having 2 slashes in a row in the regexp below
 
         for line in lines:
-            line = urllib.unquote(line).decode('utf8')
+            line = urllib.parse.unquote(line)#.decode('utf8')
             m = re.search('^get -O %s(.*) ftp://(.*)%s/(.*)$' %
                           (self.output_dir, self.lftp_subdir), line)
             if m:

--- a/lib/python/platform_code_vocab.py
+++ b/lib/python/platform_code_vocab.py
@@ -16,7 +16,7 @@ How to use:
 author : Besnard, Laurent
 """
 
-import urllib
+from urllib.request import urlopen
 import warnings
 import xml.etree.ElementTree as ET
 
@@ -28,7 +28,7 @@ def platform_type_uris_by_category():
     """
     platform_cat_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform-category/aodn_aodn-platform-category-vocabulary.rdf'
     # platform_cat_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/112/aodn_aodn-platform-category-vocabulary_version-1-0.rdf'
-    response = urllib.request.urlopen(platform_cat_vocab_url)
+    response = urlopen(platform_cat_vocab_url)
     html = response.read()
     root = ET.fromstring(html)
     platform_cat_list = {}
@@ -70,7 +70,7 @@ def platform_altlabels_per_preflabel(category_name=None):
 
     platform_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform/aodn_aodn-platform-vocabulary.rdf'
     # platform_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/373/aodn_aodn-platform-vocabulary_version-1-3.rdf'
-    response = urllib.request.urlopen(platform_vocab_url)
+    response = urlopen(platform_vocab_url)
     html = response.read()
     root = ET.fromstring(html)
     platform = {}

--- a/lib/python/platform_code_vocab.py
+++ b/lib/python/platform_code_vocab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env 3.5
 # -*- coding: utf-8 -*-
 """
 Find the platform_code platform_name equivalence from poolparty platform vocab
@@ -16,7 +16,7 @@ How to use:
 author : Besnard, Laurent
 """
 
-import urllib2
+import urllib
 import warnings
 import xml.etree.ElementTree as ET
 
@@ -28,15 +28,15 @@ def platform_type_uris_by_category():
     """
     platform_cat_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform-category/aodn_aodn-platform-category-vocabulary.rdf'
     # platform_cat_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/112/aodn_aodn-platform-category-vocabulary_version-1-0.rdf'
-    response               = urllib2.urlopen(platform_cat_vocab_url)
-    html                   = response.read()
-    root                   = ET.fromstring(html)
-    platform_cat_list      = {}
+    response = urllib.request.urlopen(platform_cat_vocab_url)
+    html = response.read()
+    root = ET.fromstring(html)
+    platform_cat_list = {}
 
     for item in root:
         if 'Description' in item.tag:
             platform_cat_url_list = []
-            platform_cat          = None
+            platform_cat = None
 
             for val in item:
                 platform_element_sublabels = val.tag
@@ -44,7 +44,7 @@ def platform_type_uris_by_category():
                 # handle more than 1 url match per category of platform
                 if platform_element_sublabels is not None:
                     if 'narrowMatch' in platform_element_sublabels:
-                        val_cat_url = val.attrib.values()[0]
+                        val_cat_url = [item for item in val.attrib.values()][0]
                         platform_cat_url_list.append(val_cat_url)
 
                     elif 'prefLabel' in platform_element_sublabels:
@@ -55,6 +55,7 @@ def platform_type_uris_by_category():
 
     response.close()
     return platform_cat_list
+
 
 def platform_altlabels_per_preflabel(category_name=None):
     """
@@ -69,11 +70,11 @@ def platform_altlabels_per_preflabel(category_name=None):
 
     platform_vocab_url = 'http://content.aodn.org.au/Vocabularies/platform/aodn_aodn-platform-vocabulary.rdf'
     # platform_vocab_url = 'http://vocabs.ands.org.au/repository/api/download/373/aodn_aodn-platform-vocabulary_version-1-3.rdf'
-    response           = urllib2.urlopen(platform_vocab_url)
-    html               = response.read()
-    root               = ET.fromstring(html)
-    platform           = {}
-    filter_cat_type    = False
+    response = urllib.request.urlopen(platform_vocab_url)
+    html = response.read()
+    root = ET.fromstring(html)
+    platform = {}
+    filter_cat_type = False
 
     if category_name:
         # a platform category is defined by a list of urls.
@@ -83,7 +84,7 @@ def platform_altlabels_per_preflabel(category_name=None):
         filter_cat_list = platform_type_uris_by_category()
         if filter_cat_name in filter_cat_list.keys():
             filter_cat_url_list = filter_cat_list[filter_cat_name]
-            filter_cat_type     = True
+            filter_cat_type = True
         else:
             warnings.warn("Platform category %s not in platform category vocabulary" % filter_cat_name)
 
@@ -92,8 +93,8 @@ def platform_altlabels_per_preflabel(category_name=None):
         if 'Description' in item.tag:
             # for every element, iterate over the sub elements and look for
             # common platform label
-            platform_code    = []
-            platform_name    = None
+            platform_code = []
+            platform_name = None
             platform_url_cat = None
 
             for val in item:
@@ -108,7 +109,7 @@ def platform_altlabels_per_preflabel(category_name=None):
                         platform_name = val.text
 
                     elif 'broader' in platform_element_sublabels:
-                        val_cat_url      = val.attrib.values()[0]
+                        val_cat_url = [item for item in val.attrib.values()][0]
                         platform_url_cat = val_cat_url
 
             # use the optional argument

--- a/lib/python/ship_callsign.py
+++ b/lib/python/ship_callsign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 # -*- coding: utf-8 -*-
 """
 Reads the ship_callsign from platform vocab and returns a dictionnary of
@@ -32,6 +32,7 @@ def ship_callsign_list():
         platform_codes['FASB'] = 'Astrolabe'
 
     return platform_codes
+
 
 def ship_callsign(callsign):
     """

--- a/lib/python/util.py
+++ b/lib/python/util.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.5
 """
 various utils which don't fit anywhere else
 imports could be in functions for portability reasons

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ Fiona==1.7.1
 wand==0.4.4
 xlrd
 functools32
+beautifulsoup4


### PR DESCRIPTION
NOT TO MERGE

In order to test the following code change work well with python 3, the following commands should run successfully:
 * ```ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py```
 * ```FAIMMS/REALTIME/faimms.py```
 * ```SOOP/SOOP_TRV/soop_trv.py```
 * ```SOOP/SOOP_ASF_SST_XBT/SOOP_XBT_NRT.py```
 * ```SOOP/SOOP_ASF_SST_XBT/SOOP_BOM_ASF_SST.py```
 * ```SRS/SRS_OC_LJCO_AERONET/download_aeronet.py /tmp```

 * AUV has been modified as well but untested ```AUV/auv_viewer_processing/auv_processing.py``` since this has some weird gdal dependency installed via chef. So this could be more complicated to deal with. 


There are a bunch of other python code under ANMN, ABOS, AODN and AATAMS which are still using pipeline v1. They need to be converted soon to use pipeline v2.

The following codes are running on personnal machines, or for other users. And don't really need to be updated (as yet):
 * SOOP/SOOP_XBT/DELAYED
 * SRS/SRS_OC_BODBAW

This code was written by Ankit, and should be ported I guess to python 3.5:
 * bin/geonetwork_broken_link_checker.py

@craigrose FYO