### PR TITLE
Remove ANMN_AM code from list of tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,6 @@
 TESTS="$TESTS lib/test/common/shunit2_test.sh"
 TESTS="$TESTS lib/python/test_file_classifier.py"
 
-TESTS="$TESTS ANMN/AM/test_dest_path.py"
 TESTS="$TESTS ANMN/common/test_dest_path.py"
 TESTS="$TESTS ANMN/common/test_previous_versions.py"
 


### PR DESCRIPTION
The Acidification Moorings pipeline has been moved to v2. The obsolete code here was deleted by #952, but we forgot to remove the unittest from the list of tests that is run by the data_services_prod_merge job on Jenkins.