### PR TITLE
AIMS services - md5 checks different with different python versions

### DIFF
--- a/ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py
+++ b/ANMN/NRS_AIMS/REALTIME/anmn_nrs_aims.py
@@ -29,6 +29,7 @@ author Laurent Besnard, laurent.besnard@utas.edu.au
 import argparse
 import datetime
 import os
+import sys
 import re
 import shutil
 import traceback
@@ -276,7 +277,11 @@ class AimsDataValidationTest(data_validation_test.TestCase):
         shutil.rmtree(os.path.dirname(self.netcdf_tmp_file_path))
 
     def test_aims_validation(self):
-        self.md5_expected_value = '76c9a595264a8173545b6dc0c518a280'
+        if sys.version_info[0] < 3:
+            self.md5_expected_value = '76c9a595264a8173545b6dc0c518a280'
+        else:
+            self.md5_expected_value = '96c025179afcfcfd0f105473332719f0'
+
         self.md5_netcdf_value   = md5(self.netcdf_tmp_file_path)
 
         self.assertEqual(self.md5_netcdf_value, self.md5_expected_value)

--- a/FAIMMS/REALTIME/faimms.py
+++ b/FAIMMS/REALTIME/faimms.py
@@ -28,6 +28,7 @@ author Laurent Besnard, laurent.besnard@utas.edu.au
 import argparse
 import datetime
 import os
+import sys
 import re
 import shutil
 import traceback
@@ -261,7 +262,11 @@ class AimsDataValidationTest(data_validation_test.TestCase):
         shutil.rmtree(os.path.dirname(self.netcdf_tmp_file_path))
 
     def test_aims_validation(self):
-        self.md5_expected_value = '20eeb53140d06e9cbea7e941caa108b5'
+        if sys.version_info[0] < 3:
+            self.md5_expected_value = '20eeb53140d06e9cbea7e941caa108b5'
+        else:
+            self.md5_expected_value = '67f116b43dd8592373fb94438e619d93'
+
         self.md5_netcdf_value   = md5(self.netcdf_tmp_file_path)
 
         self.assertEqual(self.md5_netcdf_value, self.md5_expected_value)

--- a/SOOP/SOOP_TRV/soop_trv.py
+++ b/SOOP/SOOP_TRV/soop_trv.py
@@ -12,6 +12,7 @@ author Laurent Besnard, laurent.besnard@utas.edu.au
 
 import os
 import shutil
+import sys
 import traceback
 import unittest as data_validation_test
 from datetime import datetime
@@ -267,8 +268,12 @@ class AimsDataValidationTest(data_validation_test.TestCase):
         shutil.rmtree(os.path.dirname(self.netcdf_tmp_file_path))
 
     def test_aims_validation(self):
-        self.md5_expected_value = '18770178cd71c228e8b59ccba3c7b8b5'
-        self.md5_netcdf_value   = md5(self.netcdf_tmp_file_path)
+        if sys.version_info[0] < 3:
+            self.md5_expected_value = '18770178cd71c228e8b59ccba3c7b8b5'
+        else:
+            self.md5_expected_value = '3464ee1a8bcd600645b6cdb7516fd9e4'
+
+        self.md5_netcdf_value = md5(self.netcdf_tmp_file_path)
 
         self.assertEqual(self.md5_netcdf_value, self.md5_expected_value)
 


### PR DESCRIPTION
@lwgordonimos 
as discussed previously, those main scripts modify the downloaded files. the md5 are different according to the python version