### PR TITLE
conda environment file

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - numpy
   - pip:
     - -r file:requirements.txt
+    - -c file:constraints.txt
     - "git+https://github.com/aodn/cc-plugin-imos.git"
-

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: data_services_3.5
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.5
+  - pip
+  - numpy
+  - pip:
+    - -r file:requirements.txt
+    - "git+https://github.com/aodn/cc-plugin-imos.git"
+

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - python=3.5
-  - pip
+  - pip>=20.0.2
   - numpy
   - pip:
     - -r file:requirements.txt


### PR DESCRIPTION
simple way to provisionning a conda virtual env
```bash
conda env create -f environment.yml
```

or to update

```bash
conda env update -f environment.yml
```

This install all the packages as specified in the existing requirements.txt as well as the imos_cc_plugin

I have tested this a few times, by removing the already cache files from my ~/.cache/pip. Everything seems to work well. If we merge this, it would be good to update the README.md file

@lwgordonimos 
@aodn/data-ops FYI