### PR TITLE
Update requirements.txt to support Ubuntu 20 upgrade

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 cftime<1.1.1
+pyproj<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ geopy==1.11.0
 matplotlib==1.5.1
 netCDF4==1.5.3
 numpy==1.16.5
-pandas==0.18.1
+pandas==0.18.1; python_version < '3.6'
+pandas==1.2.0; python_version > '3.5'
 python-dateutil
 python-dotenv==0.5.1
 requests>=2.22.0
@@ -12,7 +13,8 @@ pyexcel==0.5.15
 pyexcel-xls==0.5.8
 pyexcel-xlsx==0.5.8
 retrying==1.3.3
-scipy==0.14.1
+scipy==0.14.1; python_version < '3.6'
+scipy==1.4.1; python_version > '3.5'
 six
 tendo==0.2.15
 click


### PR DESCRIPTION
Because of the additional version constraint in requirements.txt, this will retain the current versions for the current servers, while allowing testing on Ubuntu 20 to proceed (as the old versions are too old for Python 3.8).