### PR TITLE
(Feat) standalone python script to list imos-data objects

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,7 @@
+# An environment file for Project Officers wanted to use Conda rather than
+# virtualenv
+# conda env create --file=environment.yml
+# conda env update --file=environment.yml
 name: data_services_3.6
 channels:
   - conda-forge
@@ -6,6 +10,8 @@ dependencies:
   - python=3.6
   - pip>=20.0.2
   - numpy
+  - awscli
+  - boto3
   - pip:
     - -r requirements.txt
     - -c constraints.txt

--- a/lib/python/s3_ls_prefix.py
+++ b/lib/python/s3_ls_prefix.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
 # script to list s3 object from an AODN bucket to stdout
-# requires credential to be set up with `aws configure`
-# aws binary can be install via `pip install awscl`
-# Example: ./s3_ls_prefix.py -p 'Defence_Technology_Agency-New_Zealand/Waverider_Buoys_C-20200615T000000Z/'
 # author: laurent Besnard
 
 import argparse
 import boto3
 import sys
 import os
+
+EXAMPLE_TEXT = """
+Requirements:
+  1) set up credentials with `aws configure` (binary coming from awscli package)
+  2) download file
+     https://github.com/aodn/cloud-deploy/blob/master/sample-config/aws/config_projectofficer
+     copy and rename to ~/.aws/config
+
+Examples:
+  ./s3_ls_prefix.py -p 'Defence_Technology_Agency-New_Zealand/Waverider_Buoys_C-20200615T000000Z/' \n
+  ./s3_ls_prefix.py -b imos-test-data -p 'Defence_Technology_Agency'
+"""
 
 
 def _s3_ls_bucket_prefix(bucket, prefix):
@@ -27,7 +36,9 @@ def args():
     define the script arguments
     :return: vargs
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(epilog=EXAMPLE_TEXT,
+                                     description='script to list s3 object from an AODN bucket to stdout',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-p", "--prefix",
                         type=str,
                         help="s3 prefix - Example ''IMOS/SOOP'")

--- a/lib/python/s3_ls_prefix.py
+++ b/lib/python/s3_ls_prefix.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# script to list s3 object from an AODN bucket to stdout
+# requires credential to be set up with `aws configure`
+# Example: ./s3_ls_prefix.py -p 'Defence_Technology_Agency-New_Zealand/Waverider_Buoys_C-20200615T000000Z/'
+# author: laurent Besnard
+
+import argparse
+import boto3
+import sys
+import os
+
+
+def _s3_ls_bucket_prefix(bucket, prefix):
+    s3 = boto3.resource('s3')
+    my_bucket = s3.Bucket(bucket)
+
+    s3_obj = []
+    for object in my_bucket.objects.filter(Prefix=prefix):
+        s3_obj.append(object.key)
+
+    return s3_obj
+
+
+def args():
+    """
+    define the script arguments
+    :return: vargs
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--prefix",
+                        type=str,
+                        help="s3 prefix - Example ''IMOS/SOOP'")
+
+    parser.add_argument("-b", "--bucket",
+                        default='imos-data',
+                        type=str,
+                        help="s3 bucket - default value is 'imos-data'")
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+
+    vargs = args()
+
+    prefix = vargs.prefix
+    bucket = vargs.bucket
+    os.environ['AWS_PROFILE'] = 'production-projectofficer'
+
+    s3_obj = _s3_ls_bucket_prefix(bucket, prefix)
+    for f in s3_obj:
+        print(f, file=sys.stdout)

--- a/lib/python/s3_ls_prefix.py
+++ b/lib/python/s3_ls_prefix.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # script to list s3 object from an AODN bucket to stdout
 # requires credential to be set up with `aws configure`
+# aws binary can be install via `pip install awscl`
 # Example: ./s3_ls_prefix.py -p 'Defence_Technology_Agency-New_Zealand/Waverider_Buoys_C-20200615T000000Z/'
 # author: laurent Besnard
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ matplotlib==1.5.1
 netCDF4==1.5.3
 numpy==1.16.5
 pandas==0.18.1; python_version < '3.6'
-pandas==1.2.0; python_version > '3.5'
+pandas>=1.1.5; python_version > '3.5'
 python-dateutil
 python-dotenv==0.5.1
 requests>=2.22.0


### PR DESCRIPTION
A standalone python script to output object to stdout. Can then easily be used
with po_s3_del
```bash
./s3_ls_prefix.py -h
usage: s3_ls_prefix.py [-h] [-p PREFIX] [-b BUCKET]

optional arguments:
  -h, --help            show this help message and exit
  -p PREFIX, --prefix PREFIX
                        s3 prefix - Example ''IMOS/SOOP'
  -b BUCKET, --bucket BUCKET
                        s3 bucket - default value is 'imos-data'

```
