### PR TITLE
S3 download objects

### DIFF
--- a/FAIMMS/REALTIME/faimms.py
+++ b/FAIMMS/REALTIME/faimms.py
@@ -36,6 +36,7 @@ import traceback
 import unittest as data_validation_test
 
 from netCDF4 import Dataset
+from itertools import groupby
 from tendo import singleton
 
 from aims_realtime_util import (convert_time_cf_to_imos,
@@ -48,7 +49,8 @@ from aims_realtime_util import (convert_time_cf_to_imos,
                                 modify_aims_netcdf, parse_aims_xml,
                                 remove_dimension_from_netcdf,
                                 remove_end_date_from_filename, save_channel_info,
-                                set_up, rm_tmp_dir, get_main_netcdf_var)
+                                set_up, rm_tmp_dir, get_main_netcdf_var,
+                                list_recursively_files_abs_path)
 from dest_path import get_faimms_platform_type, get_faimms_site_name
 from util import pass_netcdf_checker
 
@@ -351,15 +353,20 @@ if __name__ == '__main__':
 
             process_qc_level(level)
 
-            if len(os.listdir(TMP_MANIFEST_DIR)) > 0:
-                incoming_dir_file = os.path.join(DATA_WIP_PATH, 'faimms_FV0{level}_{date}.dir_manifest'.format(
-                    level=str(level),
-                    date=date_str_now))
+            lines_per_file = 2**12
+            file_list = list_recursively_files_abs_path(TMP_MANIFEST_DIR)
+            if len(file_list) > 0:
+                for file_number, lines in groupby(enumerate(file_list), key=lambda x: x[0] // lines_per_file):
+                    incoming_file = os.path.join(DATA_WIP_PATH, 'faimms_FV0{level}_{date}_{file_number}.manifest'.format(
+                        level=str(level),
+                        date=date_str_now,
+                        file_number=file_number))
+                    with open(incoming_file, 'w') as outfile:
+                        for item in lines:
+                            outfile.write("%s\n" % item[1])
 
-                with open(incoming_dir_file, 'w') as manifest_file:
-                    manifest_file.write("%s\n" % TMP_MANIFEST_DIR)
+                    os.chmod(incoming_file, 0o0664)  # change to 664 for pipeline v2
+                    shutil.move(incoming_file, os.path.join(FAIMMS_INCOMING_DIR, os.path.basename(incoming_file)))
 
-                os.chmod(incoming_dir_file, 0o0664)  # change to 664 for pipeline v2
-                shutil.move(incoming_dir_file, os.path.join(FAIMMS_INCOMING_DIR, os.path.basename(incoming_dir_file)))
     else:
         logger.error('Data validation unittests failed')

--- a/lib/python/aims_realtime_util.py
+++ b/lib/python/aims_realtime_util.py
@@ -11,6 +11,7 @@ data.aims.gov.au/gbroosdata/services/rss/netcdf/level0/300  -> NRS DARWIN YONGAL
 author Laurent Besnard, laurent.besnard@utas.edu.au
 """
 import datetime
+import glob
 import json
 import logging
 import os
@@ -253,6 +254,19 @@ def create_list_of_dates_to_download(channel_id, level_qc, from_date, thru_date)
         end_dates[-1] = thru_date
 
     return start_dates, end_dates
+
+
+def list_recursively_files_abs_path(path):
+    """
+    return a list containing the absolute path of files recursively found in a path
+    :param path:
+    :return:
+    """
+    filelist = []
+    for filename in glob.glob('{path}/**'.format(path=path), recursive=True):
+        if os.path.isfile(filename):
+            filelist.append(os.path.abspath(filename))
+    return filelist
 
 
 def md5(fname):

--- a/lib/python/s3_ls_prefix.py
+++ b/lib/python/s3_ls_prefix.py
@@ -6,6 +6,7 @@ import argparse
 import boto3
 import sys
 import os
+import urllib
 
 EXAMPLE_TEXT = """
 Requirements:
@@ -15,10 +16,12 @@ Requirements:
      copy and rename to ~/.aws/config
 
 Examples:
-  ./s3_ls_prefix.py -p 'Defence_Technology_Agency-New_Zealand/Waverider_Buoys_C-20200615T000000Z/' \n
+  ./s3_ls_prefix.py -p 'Defence_Technology_Agency-New_Zealand/Waverider_Buoys_C-20200615T000000Z/'
   ./s3_ls_prefix.py -b imos-test-data -p 'Defence_Technology_Agency'
+  ./s3_ls_prefix.py -p IMOS/ACORN/gridded_1h-avg-current-map_QC/NWA/2021/07/ -o /tmp/nwa_dm
 """
 
+URL_PREFIX="https://s3-ap-southeast-2.amazonaws.com"
 
 def _s3_ls_bucket_prefix(bucket, prefix):
     s3 = boto3.resource('s3')
@@ -31,13 +34,27 @@ def _s3_ls_bucket_prefix(bucket, prefix):
     return s3_obj
 
 
+def _download_s3_obj_flat(bucket, s3_obj_ls, output_dir):
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    for f in s3_obj_ls:
+        url='{prefix_url}/{bucket}/{object_path}'.format(prefix_url=URL_PREFIX,
+                                                        bucket=bucket,
+                                                        object_path=f)
+        output_file = os.path.join(output_dir, os.path.basename(f))
+
+        print('Downloading {f}'.format(f=f), file=sys.stdout)
+        urllib.request.urlretrieve(url, output_file)
+
+
 def args():
     """
     define the script arguments
     :return: vargs
     """
     parser = argparse.ArgumentParser(epilog=EXAMPLE_TEXT,
-                                     description='script to list s3 object from an AODN bucket to stdout',
+                                     description='script to list/download s3 object from an AODN bucket to stdout',
                                      formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-p", "--prefix",
                         type=str,
@@ -47,6 +64,10 @@ def args():
                         default='imos-data',
                         type=str,
                         help="s3 bucket - default value is 'imos-data'")
+
+    parser.add_argument("-o", "--output-dir",
+                        type=str,
+                        help="download listed objects to --output-dir")
 
     return parser.parse_args()
 
@@ -59,6 +80,10 @@ if __name__ == '__main__':
     bucket = vargs.bucket
     os.environ['AWS_PROFILE'] = 'production-projectofficer'
 
-    s3_obj = _s3_ls_bucket_prefix(bucket, prefix)
-    for f in s3_obj:
-        print(f, file=sys.stdout)
+    s3_obj_ls = _s3_ls_bucket_prefix(bucket, prefix)
+    if vargs.output_dir:
+        _download_s3_obj_flat(bucket, s3_obj_ls, vargs.output_dir)
+    else:
+        for f in s3_obj_ls:
+            print(f, file=sys.stdout)
+


### PR DESCRIPTION
- (Fix) FAIMMS - output downloaded NetCDF to *.manifest instead of deprecated *.manifest_dir
- (Feat) add download option to s3_ls_prefix python script
