### PR TITLE
Include cf-units constraint

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 cftime<1.1.1
 pyproj<3
+cf-units<=2.1.5


### PR DESCRIPTION
Required to successfully compile on Ubuntu 20.04 pipeline box with system python v3.8.5