### PR TITLE
Constrain numpy version to avoid deprecation issue

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,7 @@
 cftime<1.1.1
 pyproj<3
 cf-units<=2.1.5
+
+# Current versions of compliance-checker (5.0.1) and cc-plugin-imos (1.5.3) both use deprecated types
+# numpy.float / numpy.int which have been removed in numpy 1.24
+numpy<1.24.0


### PR DESCRIPTION
Fixes https://github.com/aodn/issues/issues/1322

See also https://github.com/aodn/python-aodndata/pull/341 and aodn/python-aodncore#272