### PR TITLE
Put profile metadata files into their own directory

### DIFF
--- a/ARGO/oceancurrent/argo_oceancurrent.py
+++ b/ARGO/oceancurrent/argo_oceancurrent.py
@@ -5,6 +5,7 @@ import json
 
 # Specify the directory path
 PROFILES_PATH = "/mnt/oceancurrent/website/profiles/"
+METADATA_PATH = "/mnt/oceancurrent/metadata/"
 
 
 def main():
@@ -40,7 +41,9 @@ def main():
         profiles_json = json.dumps(profiles, indent=4)
 
         # Write the JSON string to a file in the path of the profile
-        profile_json_path = os.path.join(profile_path, "profiles.json")
+        metadata_path = os.path.join(METADATA_PATH, platform_code)
+        os.makedirs(metadata_path, exist_ok=True)
+        profile_json_path = os.path.join(metadata_path, "profiles.json")
 
         with open(profile_json_path, "w") as f:
             f.write(profiles_json)

--- a/ARGO/oceancurrent/test_argo_oceancurrent.py
+++ b/ARGO/oceancurrent/test_argo_oceancurrent.py
@@ -14,12 +14,14 @@ class TestProfilesJsonGeneration(unittest.TestCase):
         # Create a temporary directory
         self.test_dir = tempfile.mkdtemp()
         self.profiles_test_dir = os.path.join(self.test_dir, 'mnt/oceancurrent/website/profiles')
+        self.metadata_test_dir = os.path.join(self.test_dir, 'mnt/oceancurrent/metadat')
 
         # Path to the existing test files
         self.existing_test_files_path = os.path.join(os.path.dirname(__file__), 'tests')
 
         # Copy all test files to the temporary directory
         for item in os.listdir(self.existing_test_files_path):
+            print(item)
             s = os.path.join(self.existing_test_files_path, item)
             d = os.path.join(self.test_dir, item)
             if os.path.isdir(s):
@@ -33,53 +35,55 @@ class TestProfilesJsonGeneration(unittest.TestCase):
 
     def test_profiles_json_generation(self):
         with patch('argo_oceancurrent.PROFILES_PATH', new=self.profiles_test_dir):
-            # Run the main from argo_oceancurrent to create the profiles.json
-            main()
+            with patch('argo_oceancurrent.METADATA_PATH', new=self.metadata_test_dir):
+                # Run the main from argo_oceancurrent to create the profiles.json
+                main()
 
-            # Verify the generated profiles.json for one platform code
-            platform_code = '7901108'
-            generated_json_path = os.path.join(self.profiles_test_dir, platform_code, "profiles.json")
-            self.assertTrue(os.path.exists(generated_json_path), f"{generated_json_path} was not created")
+                # Verify the generated profiles.json for one platform code
+                platform_code = '7901108'
+                generated_json_path = os.path.join(self.metadata_test_dir, platform_code, "profiles.json")
+                self.assertTrue(os.path.exists(generated_json_path), f"{generated_json_path} was not created")
 
-            with open(generated_json_path, 'r') as f:
-                generated_json = json.load(f)
+                with open(generated_json_path, 'r') as f:
+                    generated_json = json.load(f)
 
-            # Define the expected JSON content based on the test files
-            expected_json = [
-                {
-                    "date": "20240415",
-                    "cycle": "4",
-                    "filename": "20240415_7901108_4.gif"
-                },
-                {
-                    "date": "20240506",
-                    "cycle": "6",
-                    "filename": "20240506_7901108_6.gif"
-                },
-                {
-                    "date": "20240516",
-                    "cycle": "7",
-                    "filename": "20240516_7901108_7.gif"
-                },
-                {
-                    "date": "20240405",
-                    "cycle": "3",
-                    "filename": "20240405_7901108_3.gif"
-                },
-                {
-                    "date": "20240426",
-                    "cycle": "5",
-                    "filename": "20240426_7901108_5.gif"
-                },
-                {
-                    "date": "20240526",
-                    "cycle": "8",
-                    "filename": "20240526_7901108_8.gif"
-                }
-            ]
+                # Define the expected JSON content based on the test files
+                expected_json = [
+                    {
+                        "date": "20240415",
+                        "cycle": "4",
+                        "filename": "20240415_7901108_4.gif"
+                    },
+                    {
+                        "date": "20240506",
+                        "cycle": "6",
+                        "filename": "20240506_7901108_6.gif"
+                    },
+                    {
+                        "date": "20240516",
+                        "cycle": "7",
+                        "filename": "20240516_7901108_7.gif"
+                    },
+                    {
+                        "date": "20240405",
+                        "cycle": "3",
+                        "filename": "20240405_7901108_3.gif"
+                    },
+                    {
+                        "date": "20240426",
+                        "cycle": "5",
+                        "filename": "20240426_7901108_5.gif"
+                    },
+                    {
+                        "date": "20240526",
+                        "cycle": "8",
+                        "filename": "20240526_7901108_8.gif"
+                    }
+                ]
 
-            self.assertEqual(generated_json, expected_json, f"The generated profiles.json content in {platform_code} is incorrect")
+                self.assertEqual(generated_json, expected_json,
+                                 f"The generated profiles.json content in {platform_code} is incorrect")
+
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
For https://github.com/aodn/backlog/issues/5691

Due to daily refresh of website content, we have to put the jsons in a separate directory

Test failing but doesn't seem to be related to my code changes. Order of the files within the json seems to be different to what it was when @lbesnard created the tests but otherwise content is correct I think?