### PR TITLE
remove deployment data unavailable

### DIFF
--- a/AODN/AODN-WAVE-NRT/ARDC_API_NRT/ardc_nrt/config/sofar/sources_id_metadata.json
+++ b/AODN/AODN-WAVE-NRT/ARDC_API_NRT/ardc_nrt/config/sofar/sources_id_metadata.json
@@ -1024,31 +1024,6 @@
     "water_depth_units": "m",
     "wave_buoy_type": "directional"
   },
-  "SPOT-30852C":
-  {
-    "spotter_id": "SPOT-30852C",
-    "site_name": "Robe Guichen Bay",
-    "latitude_nominal": -37.148,
-    "longitude_nominal": 139.77,
-    "deployment_start_date": "2025-01-20T00:00:00.000Z",
-    "institution": "SARDI Flinders University",
-    "institution_code": "SA-DEW",
-    "abstract": "Near real time integral wave parameters from wave buoys collected by SARDI-Flinders University using a SOFAR Spotter-V3 at Robe Guichen Bay",
-    "title": "Near real time integral wave parameters from wave buoys collected by SARDI-Flinders University using a SOFAR Spotter-V3 at Robe Guichen Bay",
-    "instrument": "SOFAR Spotter-V3",
-    "instrument_burst_interval": 1800,
-    "instrument_burst_duration": 1800,
-    "instrument_burst_units": "s",
-    "instrument_sampling_interval": 0.4,
-    "platform": "moored surface buoy",
-    "wave_motion_sensor_type": "GPS",
-    "wave_sensor_serial_number": "SPOT-30852C",
-    "hull_serial_number": "",
-    "transmission": "Iridium/Cellular",
-    "water_depth": 10,
-    "water_depth_units": "m",
-    "wave_buoy_type": "directional"
-  },
   "SPOT-31751C":
   {
     "spotter_id": "SPOT-31751C",


### PR DESCRIPTION
`Robe Guichen Bay` site seems to not be sending data (`ERROR - SPOT-30852C: API not returning latest date`)

However, I'm unsure to remove it for several reasons:
- the spotter is listed under SA_FLINDER and not SA_DEW, even using the SA_FLINDER token, I can't access the latest data
- on [thredds](https://thredds.aodn.org.au/thredds/catalog/Flinders_University/WAVE-BUOYS/REALTIME/WAVE-PARAMETERS/ROBE-INSHORE/catalog.html) there are data until 2024 at `Robe inshore` site
- based on the metadata spreadsheet, there was a deployment of this spotter ( SPOT-30852C) on 2025-01-20 but the site is called `Robe Guichen Bay`, not `Robe inshore ` as shown when listing the spotter IDs available under the token
```
sofarApi().get_devices_info(sofarApi().lookup_get_tokens()['SA-FLINDERS']) 
4             Robe inshore  SPOT-30852C
```
- As it was deployed in January, there is a chance it's been recovered but in that case we never published data

@bpasquer if you think it should be removed from the config please merge this PR, if not let's have a chat and I'll contact the facility